### PR TITLE
✨ feat(navigation): add mouse scroll and vim-style g/G navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "mq-lang"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcec9a81ff2a19311282a74424991ea47bf32fd4eecb0b0c013762f5791ff466"
+checksum = "7af06a353da280055e9eac62d16ebcd7a3314207ca9275688677b7d6331950a4"
 dependencies = [
  "base64",
  "chrono",
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "mq-markdown"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a24e772fd4dbe02ad6d9d408ab81daadcdbcd7bc0d2456acc3d2e679f9d0b95"
+checksum = "7b2612249610d88646e121aa19de44bc0cafb91a14e3e6b5c7d13921d8d77c49"
 dependencies = [
  "ego-tree",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ crossterm = {version = "0.29.0", features = ["event-stream", "use-dev-tty"]}
 itertools = "0.14.0"
 log = "0.4.29"
 miette = {version = "7.6.0", features = ["fancy"]}
-mq-lang = "0.5.27"
-mq-markdown = "0.5.27"
+mq-lang = "0.5.28"
+mq-markdown = "0.5.28"
 ratatui = "0.30.0"
 unicode-width = "0.2.2"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use arboard::Clipboard;
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEventKind};
 use miette::IntoDiagnostic;
 use mq_lang::Engine;
 use mq_markdown::Markdown;
@@ -154,6 +154,23 @@ impl App {
     }
 
     fn handle_normal_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Mouse(mouse_event) = event {
+            match mouse_event.kind {
+                MouseEventKind::ScrollDown => {
+                    if !self.results.is_empty() {
+                        self.selected_idx = self.next_visible_from_current(true);
+                    }
+                }
+                MouseEventKind::ScrollUp => {
+                    if !self.results.is_empty() {
+                        self.selected_idx = self.next_visible_from_current(false);
+                    }
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
+
         if let Event::Key(KeyEvent {
             code,
             modifiers,
@@ -236,6 +253,18 @@ impl App {
                     }
                 }
                 (KeyCode::End, _) => {
+                    if !self.results.is_empty() {
+                        let last = self.results.len() - 1;
+                        self.selected_idx = self.next_visible(last, false);
+                    }
+                }
+                // Jump to first/last result (vim-style)
+                (KeyCode::Char('g'), _) => {
+                    if !self.results.is_empty() {
+                        self.selected_idx = self.next_visible(0, true);
+                    }
+                }
+                (KeyCode::Char('G'), _) => {
                     if !self.results.is_empty() {
                         let last = self.results.len() - 1;
                         self.selected_idx = self.next_visible(last, false);
@@ -407,6 +436,23 @@ impl App {
     }
 
     fn handle_tree_view_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Mouse(mouse_event) = event {
+            match mouse_event.kind {
+                MouseEventKind::ScrollDown => {
+                    if let Some(tree_view) = &mut self.tree_view {
+                        tree_view.move_down();
+                    }
+                }
+                MouseEventKind::ScrollUp => {
+                    if let Some(tree_view) = &mut self.tree_view {
+                        tree_view.move_up();
+                    }
+                }
+                _ => {}
+            }
+            return Ok(());
+        }
+
         if let Event::Key(KeyEvent {
             code,
             modifiers,
@@ -438,6 +484,17 @@ impl App {
                 (KeyCode::Enter, _) | (KeyCode::Char(' '), _) => {
                     if let Some(tree_view) = &mut self.tree_view {
                         tree_view.toggle_expand();
+                    }
+                }
+                // Jump to first/last item (vim-style)
+                (KeyCode::Char('g'), _) => {
+                    if let Some(tree_view) = &mut self.tree_view {
+                        tree_view.move_to_first();
+                    }
+                }
+                (KeyCode::Char('G'), _) => {
+                    if let Some(tree_view) = &mut self.tree_view {
+                        tree_view.move_to_last();
                     }
                 }
                 // Show help

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -306,6 +306,14 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::raw(" - Move down"),
         ]),
         Line::from(vec![
+            Span::styled("g", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Jump to first result"),
+        ]),
+        Line::from(vec![
+            Span::styled("G", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Jump to last result"),
+        ]),
+        Line::from(vec![
             Span::styled("PgUp", Style::default().fg(Color::Yellow)),
             Span::raw(" - Page up"),
         ]),
@@ -392,6 +400,14 @@ fn draw_help_screen(frame: &mut Frame) {
         Line::from(vec![
             Span::styled("↓/j", Style::default().fg(Color::Yellow)),
             Span::raw(" - Move down in tree"),
+        ]),
+        Line::from(vec![
+            Span::styled("g", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Jump to first node"),
+        ]),
+        Line::from(vec![
+            Span::styled("G", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Jump to last node"),
         ]),
         Line::from(vec![
             Span::styled("Enter/Space", Style::default().fg(Color::Yellow)),

--- a/src/ui/treeview.rs
+++ b/src/ui/treeview.rs
@@ -238,6 +238,16 @@ impl TreeView {
         }
     }
 
+    pub fn move_to_first(&mut self) {
+        self.selected_index = 0;
+    }
+
+    pub fn move_to_last(&mut self) {
+        if !self.items.is_empty() {
+            self.selected_index = self.items.len() - 1;
+        }
+    }
+
     pub fn toggle_expand(&mut self) {
         if let Some(item) = self.items.get(self.selected_index)
             && item.has_children

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use mq_tui::{App, Mode};
 
 fn create_test_app() -> App {
@@ -246,4 +246,89 @@ fn test_resize_event() {
 
     app.handle_event(Event::Resize(100, 50)).unwrap();
     assert_eq!(app.mode(), Mode::Normal);
+}
+
+#[test]
+fn test_g_G_navigation() {
+    let mut app = create_test_app();
+    app.exec_query();
+
+    // Move down a bit first
+    app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
+        .unwrap();
+    app.handle_event(Event::Key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)))
+        .unwrap();
+    assert!(app.selected_idx() > 0);
+
+    // 'g' should jump to first
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('g'),
+        KeyModifiers::NONE,
+    )))
+    .unwrap();
+    assert_eq!(app.selected_idx(), 0);
+
+    // 'G' should jump to last visible result
+    app.handle_event(Event::Key(KeyEvent::new(
+        KeyCode::Char('G'),
+        KeyModifiers::SHIFT,
+    )))
+    .unwrap();
+    let last_idx = app.selected_idx();
+    let results = app.results();
+    assert!(last_idx < results.len());
+    // All results after last_idx should be invisible
+    for i in (last_idx + 1)..results.len() {
+        let rendered = mq_markdown::Markdown::new(vec![results[i].clone()]).to_string();
+        assert!(rendered.trim().is_empty(), "visible result at index {i} after last_idx {last_idx}");
+    }
+}
+
+#[test]
+fn test_mouse_scroll_navigation() {
+    let mut app = create_test_app();
+    app.exec_query();
+    assert_eq!(app.selected_idx(), 0);
+
+    let scroll_down = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    // Scroll down moves selection forward
+    app.handle_event(scroll_down).unwrap();
+    assert!(app.selected_idx() > 0);
+
+    let prev_idx = app.selected_idx();
+    let scroll_up = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollUp,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    // Scroll up moves selection backward
+    app.handle_event(scroll_up).unwrap();
+    assert!(app.selected_idx() < prev_idx);
+}
+
+#[test]
+fn test_mouse_scroll_ignored_in_help_mode() {
+    let mut app = create_test_app();
+    app.exec_query();
+    app.set_mode(Mode::Help);
+
+    let initial_idx = app.selected_idx();
+    let scroll_down = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::ScrollDown,
+        column: 0,
+        row: 0,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    app.handle_event(scroll_down).unwrap();
+    // In Help mode, mouse scroll should not change selection
+    assert_eq!(app.selected_idx(), initial_idx);
 }


### PR DESCRIPTION
- Add mouse wheel scroll support in normal mode and tree view mode
- Add g/G keys to jump to first/last result (vim-style)
- Add move_to_first/move_to_last methods to TreeView
- Update help screen with new keybindings
- Bump mq-lang and mq-markdown to 0.5.28