### PR TITLE
feat(treeview): add support for Callout, Embed, and WikiLink node types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "mq-lang"
-version = "0.5.31"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b51f7340c495c7d3327bec83c45ea26335dae91acb1392cc45ce2fcc2130194"
+checksum = "de5c9d2b5d689b6e2678e0c2434296adaf264badd1fd17a8bf2f8755d5d04412"
 dependencies = [
  "base64",
  "chrono",
@@ -1468,14 +1468,15 @@ dependencies = [
  "toml",
  "toon-format",
  "url",
+ "web-sys",
  "yaml-rust2",
 ]
 
 [[package]]
 name = "mq-macros"
-version = "0.5.31"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d749dc5c73bcce7a6a978636aef01de4700e0e790d88b5a514ae2d5df393cb77"
+checksum = "cd4c6c3fce40116d16af56baf6a26ddad9433b8f8a921111fabdc939f9fce2d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1484,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "mq-markdown"
-version = "0.5.31"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc96ff6f0490a589fae25145cbc61b883c7fd2d4b042f545eab954c37ed3a167"
+checksum = "160f55c054bc0739748e6d7cc7cefd123d9c9e6147dd5213b66918b98585aca4"
 dependencies = [
  "ego-tree",
  "itertools",
@@ -1500,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "mq-tui"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "arboard",
  "clap",
@@ -2729,9 +2730,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "toon-format"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d25e33e50b37f95f3b55b6e664218cac7e1a50f056a75bb4c7a6cccfbc8a8c4"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
 dependencies = [
  "indexmap",
  "serde",
@@ -2928,6 +2929,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src/ui/treeview.rs
+++ b/src/ui/treeview.rs
@@ -122,6 +122,9 @@ impl TreeItem {
             Node::MdxTextExpression(_) => "MDX Text Expression".to_string(),
             Node::MdxJsEsm(_) => "MDX JS ESM".to_string(),
             Node::Empty => "Empty".to_string(),
+            Node::Callout(c) => format!("Callout: {}", c.kind),
+            Node::Embed(e) => format!("Embed: {}", e.target),
+            Node::WikiLink(w) => format!("WikiLink: {}", w.target),
         }
     }
 


### PR DESCRIPTION
Bump mq-markdown to v0.6.1 which introduces Callout, Embed, and WikiLink nodes, and add matching display labels in TreeItem.