### PR TITLE
feat: add query completion, favorites, search, and split preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
  "hcl-primitives",
  "pratt",
  "vecmap-rs",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -1550,7 +1550,7 @@ dependencies = [
  "smol_str",
  "string-interner",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "toon-format",
  "url",
  "uuid",
@@ -1601,6 +1601,8 @@ dependencies = [
  "mq-markdown",
  "notify-debouncer-mini",
  "ratatui",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
  "unicode-width 0.2.2",
 ]
 
@@ -2888,6 +2890,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -2895,10 +2912,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2916,7 +2942,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -3404,6 +3430,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ mq-lang = "0.6.5"
 mq-markdown = "0.6.5"
 notify-debouncer-mini = "0.7.0"
 ratatui = "0.30.0"
+serde = {version = "1", features = ["derive"]}
+toml = "0.9"
 unicode-width = "0.2.2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ Interactive terminal interface for querying and manipulating Markdown content
 ### Key Features
 
 - 🔍 **Interactive Query Mode** - Real-time Markdown querying with instant results
+- ✨ **Query Completion** - Tab-completion and inline docs for mq selectors and functions
+- ⭐ **Favorite Queries** - Save named queries to disk and reuse them across sessions
+- 🔎 **Incremental Search** - Jump to matching results or tree nodes with `/`, `n`/`N`
 - 🌳 **Tree View** - Visual exploration of Markdown document structure
 - 👀 **Rendered Preview** - View Markdown rendered close to its final look, right in the terminal
+- 🪟 **Split Preview** - Show raw source side-by-side with the rendered preview
 - 📺 **Watch Mode** - Automatically reload files when they change on disk
 - 📑 **Multi-file Tabs** - Open several Markdown files at once and switch between them
 - ⚡ **Vim-style Navigation** - Efficient keyboard shortcuts (j/k, hjkl)
@@ -112,7 +116,34 @@ Press `p` to switch to a rendered preview of the active document - headings,
 bold/italic text, lists, blockquotes, code blocks, tables, and links are
 styled to look close to their final rendered form instead of raw Markdown
 syntax. Use `↑`/`k`, `↓`/`j`, `PageUp`/`PageDown`, or `g`/`G` to scroll, and
-press `p` or `Esc` to return to normal mode.
+press `p` or `Esc` to return to normal mode. Press `s` while in preview mode
+to split the view and show the raw Markdown source side-by-side with the
+rendered output, scrolling in sync.
+
+### Query Completion
+
+While typing a query in query mode, matching mq selectors (e.g. `.h`, `.link`)
+and functions (e.g. `select`, `flatten`) appear in a suggestion popup below
+the query box, along with a short description. Press `Tab` to insert the
+highlighted suggestion, and keep pressing `Tab` / `Shift+Tab` to cycle
+forward/backward through the other candidates. Query errors are shown
+inline under the query box as you type, instead of a blocking popup.
+
+### Favorite Queries
+
+Press `S` in normal mode to save the current query under a name; press `F`
+to browse saved queries. In the favorites list, use `↑`/`k` and `↓`/`j` to
+navigate, `Enter` to run the selected query, `d` to delete it, and `Esc` to
+close. Saved queries persist across sessions in
+`~/.config/mq-tui/queries.toml` (or your platform's equivalent config
+directory).
+
+### Incremental Search
+
+Press `/` in normal mode or tree view mode to search. Matches are jumped to
+and highlighted as you type; press `Enter` to confirm or `Esc` to cancel and
+restore your previous position. Once a search is confirmed, `n` / `N` jump
+to the next/previous match.
 
 ### Query Examples
 
@@ -149,8 +180,14 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 | `?` / `F1`  | Show help screen                     |
 | `t`         | Toggle tree view mode                |
 | `p`         | Toggle rendered preview mode          |
+| `s`         | Toggle sidebar (headers)             |
 | `d`         | Toggle detail view for selected item |
 | `y`         | Copy results to clipboard            |
+| `Y`         | Copy selected row to clipboard       |
+| `/`         | Incremental search within results    |
+| `n` / `N`   | Repeat last search forward/backward  |
+| `S`         | Save current query as a favorite     |
+| `F`         | Browse saved (favorite) queries      |
 | `Ctrl+L`    | Clear current query                  |
 | `o`         | Open a file as a new tab             |
 | `←` / `→`   | Switch tabs (when multiple files are open) |
@@ -177,6 +214,27 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 | `←` / `→`              | Move cursor in query string             |
 | `Home` / `End`         | Jump to start/end of query              |
 | `Backspace` / `Delete` | Edit query text                         |
+| `Tab` / `Shift+Tab`    | Cycle forward/backward through completion suggestions (or switch tabs if none) |
+
+### Search Mode
+
+| Key                    | Action                                   |
+| ---------------------- | --------------------------------------- |
+| `Enter`                | Confirm search, keep the new position   |
+| `Esc`                  | Cancel search, restore previous position |
+| `←` / `→`              | Move cursor in search string            |
+| `Home` / `End`         | Jump to start/end of search text        |
+| `Backspace` / `Delete` | Edit search text                        |
+
+### Favorites Mode
+
+| Key         | Action                        |
+| ----------- | ----------------------------- |
+| `↑` / `k`   | Move up                       |
+| `↓` / `j`   | Move down                     |
+| `Enter`     | Run the selected query        |
+| `d`         | Delete the selected query     |
+| `Esc` / `F` | Close the favorites list      |
 
 ### Tree View Mode
 
@@ -185,6 +243,8 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 | `↑` / `k`         | Move up in tree      |
 | `↓` / `j`         | Move down in tree    |
 | `Enter` / `Space` | Expand/collapse node |
+| `/`               | Incremental search within the tree |
+| `n` / `N`         | Repeat last search forward/backward |
 | `←` / `→`         | Switch tabs (when multiple files are open) |
 | `Esc` / `t`       | Exit tree view       |
 | `?` / `F1`        | Show help            |
@@ -209,6 +269,7 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 | `PageDown`      | Scroll down (10 lines)        |
 | `g`             | Jump to top                   |
 | `G`             | Jump to bottom                |
+| `s`             | Toggle split with raw source  |
 | `←` / `→`       | Switch tabs (when multiple files are open) |
 | `Esc` / `p`     | Exit preview                  |
 
@@ -228,7 +289,15 @@ Activated by pressing `t`. Displays the Markdown document structure as an expand
 
 ### Preview Mode
 
-Activated by pressing `p`. Renders the active document's Markdown source close to its final look - styled headings, emphasis, lists, blockquotes, code blocks, tables, and links - instead of raw Markdown syntax.
+Activated by pressing `p`. Renders the active document's Markdown source close to its final look - styled headings, emphasis, lists, blockquotes, code blocks, tables, and links - instead of raw Markdown syntax. Press `s` to split the view and show the raw source alongside the rendered preview.
+
+### Search Mode
+
+Activated by pressing `/` from normal mode or tree view mode. Jumps the selection to the nearest match as you type; the search is scoped to whichever mode it was started from (results list or tree).
+
+### Favorites Mode
+
+Activated by pressing `F`. Browse, run, and delete queries you've previously saved with `S`.
 
 ### Help Mode
 
@@ -273,6 +342,9 @@ re-applied to the updated content.
 ## Configuration
 
 `mq-tui` works out of the box with sensible defaults. The UI adapts to your terminal's color scheme and size.
+
+Favorite queries saved with `S` are stored in `~/.config/mq-tui/queries.toml`
+(honoring `XDG_CONFIG_HOME` on Linux/macOS, or `%APPDATA%\mq-tui` on Windows).
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h1 align="center">mq-tui</h1>
 
 [![ci](https://github.com/harehare/mq-tui/actions/workflows/ci.yml/badge.svg)](https://github.com/harehare/mq-tui/actions/workflows/ci.yml)
-[![mq language](https://img.shields.io/badge/mq-language-orange.svg)](https://github.com/harehare/mq)
+[![crates.io](https://img.shields.io/crates/v/mq-tui?logo=rust)](https://crates.io/crates/mq-tui)
+[![license](https://img.shields.io/crates/l/mq-tui)](LICENSE)
 
 <div align="center">
 
@@ -15,12 +16,9 @@ Interactive terminal interface for querying and manipulating Markdown content
 
 `mq-tui` is a Text-based User Interface for the [mq](https://github.com/harehare/mq) Markdown processor. It provides an interactive terminal experience for querying, filtering, and exploring Markdown documents using the mq query language.
 
-### Key Features
+## Key Features
 
 - 🔍 **Interactive Query Mode** - Real-time Markdown querying with instant results
-- ✨ **Query Completion** - Tab-completion and inline docs for mq selectors and functions
-- ⭐ **Favorite Queries** - Save named queries to disk and reuse them across sessions
-- 🔎 **Incremental Search** - Jump to matching results or tree nodes with `/`, `n`/`N`
 - 🌳 **Tree View** - Visual exploration of Markdown document structure
 - 👀 **Rendered Preview** - View Markdown rendered close to its final look, right in the terminal
 - 🪟 **Split Preview** - Show raw source side-by-side with the rendered preview
@@ -35,28 +33,29 @@ Interactive terminal interface for querying and manipulating Markdown content
 
 ## Installation
 
-### Using the Installation Script (Recommended)
+### Quick Install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/harehare/mq-tui/main/bin/install.sh | bash
-# Install from crates.io
-cargo install mq-tui
-# Install using binstall
-cargo binstall mq-tui@0.1.3
 ```
 
-The installer will:
-- Download the latest release for your platform
-- Verify the binary with SHA256 checksum
-- Install to `~/.mq-tui/bin/`
-- Update your shell profile (bash, zsh, or fish)
+Downloads the latest release for your platform, verifies it with a SHA256 checksum, installs it to `~/.mq-tui/bin/`, and updates your shell profile (bash, zsh, or fish).
 
 After installation, restart your terminal or run:
+
 ```bash
 source ~/.bashrc  # or ~/.zshrc, or ~/.config/fish/config.fish
 ```
 
-### From Source
+### Package Managers
+
+| Method            | Command                 |
+| ----------------- | ----------------------- |
+| Cargo (crates.io) | `cargo install mq-tui`  |
+| Cargo (binstall)  | `cargo binstall mq-tui` |
+
+<details>
+<summary>More install options: building from source, supported platforms</summary>
 
 ```bash
 git clone https://github.com/harehare/mq-tui.git
@@ -65,11 +64,13 @@ cargo build --release
 # Binary will be at target/release/mq-tui
 ```
 
-### Supported Platforms
+Supported platforms:
 
 - **Linux**: x86_64, aarch64
 - **macOS**: x86_64 (Intel), aarch64 (Apple Silicon)
 - **Windows**: x86_64
+
+</details>
 
 ## Usage
 
@@ -78,6 +79,12 @@ cargo build --release
 ```bash
 # Open a Markdown file
 mq-tui README.md
+
+# Read from stdin
+cat README.md | mq-tui
+
+# Launch via mq's external subcommand mechanism
+mq tui README.md
 ```
 
 ### Multiple Files (Tabs)
@@ -94,6 +101,45 @@ all tabs: whatever query you run is applied to every open file at once, so
 switching tabs shows that file's own filtered results without retyping the
 query. Press `o` at any time to open another file as a new tab.
 
+### Tree View
+
+Press `t` to display the Markdown document structure as an expandable tree,
+showing the hierarchy of headings, lists, and other elements, color-coded by
+type:
+
+- 🔵 **Blue**: Headings
+- 🟢 **Green**: Lists
+- 🔴 **Red**: Math expressions
+- 🟣 **Magenta**: Links
+- 🟡 **Yellow**: Images
+- 🔵 **Cyan**: Code blocks
+
+### Rendered Preview
+
+Press `p` to switch to a rendered preview of the active document - headings,
+bold/italic text, lists, blockquotes, code blocks, tables, and links are
+styled to look close to their final rendered form instead of raw Markdown
+syntax. Use `↑`/`k`, `↓`/`j`, `PageUp`/`PageDown`, or `g`/`G` to scroll, and
+press `p` or `Esc` to return to normal mode. Press `s` while in preview mode
+to split the view and show the raw Markdown source side-by-side with the
+rendered output, scrolling in sync.
+
+### Detail View
+
+Press `d` to toggle between list view and split view. In split view, the
+left pane shows the result list while the right pane displays detailed
+information about the selected item.
+
+### Query History
+
+Every executed query is saved in history. Use `↑` and `↓` in query mode to
+navigate through previous queries.
+
+### Clipboard Integration
+
+Press `y` to copy the current query results, or `Y` to copy just the
+selected row, to your system clipboard in Markdown format.
+
 ### Watch Mode
 
 Pass `--watch` (or `-w`) to automatically reload files when they change on disk:
@@ -109,41 +155,6 @@ no polling involved, so changes are picked up almost instantly. When a file
 is modified externally (e.g. saved from your editor, including atomic
 save-and-rename), its content is reloaded and the current query is re-run
 automatically. Watch mode is not available when reading from stdin.
-
-### Rendered Preview
-
-Press `p` to switch to a rendered preview of the active document - headings,
-bold/italic text, lists, blockquotes, code blocks, tables, and links are
-styled to look close to their final rendered form instead of raw Markdown
-syntax. Use `↑`/`k`, `↓`/`j`, `PageUp`/`PageDown`, or `g`/`G` to scroll, and
-press `p` or `Esc` to return to normal mode. Press `s` while in preview mode
-to split the view and show the raw Markdown source side-by-side with the
-rendered output, scrolling in sync.
-
-### Query Completion
-
-While typing a query in query mode, matching mq selectors (e.g. `.h`, `.link`)
-and functions (e.g. `select`, `flatten`) appear in a suggestion popup below
-the query box, along with a short description. Press `Tab` to insert the
-highlighted suggestion, and keep pressing `Tab` / `Shift+Tab` to cycle
-forward/backward through the other candidates. Query errors are shown
-inline under the query box as you type, instead of a blocking popup.
-
-### Favorite Queries
-
-Press `S` in normal mode to save the current query under a name; press `F`
-to browse saved queries. In the favorites list, use `↑`/`k` and `↓`/`j` to
-navigate, `Enter` to run the selected query, `d` to delete it, and `Esc` to
-close. Saved queries persist across sessions in
-`~/.config/mq-tui/queries.toml` (or your platform's equivalent config
-directory).
-
-### Incremental Search
-
-Press `/` in normal mode or tree view mode to search. Matches are jumped to
-and highlighted as you type; press `Enter` to confirm or `Esc` to cancel and
-restore your previous position. Once a search is confirmed, `n` / `N` jump
-to the next/previous match.
 
 ### Query Examples
 
@@ -171,180 +182,22 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 
 ## Key Bindings
 
-### Normal Mode
+| Key         | Action                      |
+| ----------- | --------------------------- |
+| `:`         | Enter query mode            |
+| `t`         | Toggle tree view            |
+| `p`         | Toggle rendered preview     |
+| `d`         | Toggle detail view          |
+| `y` / `Y`   | Copy results / selected row |
+| `o`         | Open a file as a new tab    |
+| `?` / `F1`  | Show the full help screen   |
+| `q` / `Esc` | Quit the application        |
 
-| Key         | Action                               |
-| ----------- | ------------------------------------ |
-| `q` / `Esc` | Quit the application                 |
-| `:`         | Enter query mode                     |
-| `?` / `F1`  | Show help screen                     |
-| `t`         | Toggle tree view mode                |
-| `p`         | Toggle rendered preview mode          |
-| `s`         | Toggle sidebar (headers)             |
-| `d`         | Toggle detail view for selected item |
-| `y`         | Copy results to clipboard            |
-| `Y`         | Copy selected row to clipboard       |
-| `/`         | Incremental search within results    |
-| `n` / `N`   | Repeat last search forward/backward  |
-| `S`         | Save current query as a favorite     |
-| `F`         | Browse saved (favorite) queries      |
-| `Ctrl+L`    | Clear current query                  |
-| `o`         | Open a file as a new tab             |
-| `←` / `→`   | Switch tabs (when multiple files are open) |
-| `Tab` / `Shift+Tab` | Switch tabs (when multiple files are open) |
-
-### Navigation
-
-| Key        | Action               |
-| ---------- | -------------------- |
-| `↑` / `k`  | Move up              |
-| `↓` / `j`  | Move down            |
-| `PageUp`   | Page up (10 items)   |
-| `PageDown` | Page down (10 items) |
-| `Home`     | Jump to first item   |
-| `End`      | Jump to last item    |
-
-### Query Mode
-
-| Key                    | Action                                  |
-| ---------------------- | --------------------------------------- |
-| `Enter`                | Execute query and return to normal mode |
-| `Esc`                  | Exit query mode without executing       |
-| `↑` / `↓`              | Navigate query history                  |
-| `←` / `→`              | Move cursor in query string             |
-| `Home` / `End`         | Jump to start/end of query              |
-| `Backspace` / `Delete` | Edit query text                         |
-| `Tab` / `Shift+Tab`    | Cycle forward/backward through completion suggestions (or switch tabs if none) |
-
-### Search Mode
-
-| Key                    | Action                                   |
-| ---------------------- | --------------------------------------- |
-| `Enter`                | Confirm search, keep the new position   |
-| `Esc`                  | Cancel search, restore previous position |
-| `←` / `→`              | Move cursor in search string            |
-| `Home` / `End`         | Jump to start/end of search text        |
-| `Backspace` / `Delete` | Edit search text                        |
-
-### Favorites Mode
-
-| Key         | Action                        |
-| ----------- | ----------------------------- |
-| `↑` / `k`   | Move up                       |
-| `↓` / `j`   | Move down                     |
-| `Enter`     | Run the selected query        |
-| `d`         | Delete the selected query     |
-| `Esc` / `F` | Close the favorites list      |
-
-### Tree View Mode
-
-| Key               | Action               |
-| ----------------- | -------------------- |
-| `↑` / `k`         | Move up in tree      |
-| `↓` / `j`         | Move down in tree    |
-| `Enter` / `Space` | Expand/collapse node |
-| `/`               | Incremental search within the tree |
-| `n` / `N`         | Repeat last search forward/backward |
-| `←` / `→`         | Switch tabs (when multiple files are open) |
-| `Esc` / `t`       | Exit tree view       |
-| `?` / `F1`        | Show help            |
-
-### Open File Mode
-
-| Key                    | Action                          |
-| ---------------------- | -------------------------------- |
-| `Enter`                | Open the typed path as a new tab |
-| `Esc`                  | Cancel                           |
-| `←` / `→`              | Move cursor in path string       |
-| `Home` / `End`         | Jump to start/end of path        |
-| `Backspace` / `Delete` | Edit path text                   |
-
-### Preview Mode
-
-| Key             | Action                       |
-| --------------- | ----------------------------- |
-| `↑` / `k`       | Scroll up                     |
-| `↓` / `j`       | Scroll down                   |
-| `PageUp`        | Scroll up (10 lines)          |
-| `PageDown`      | Scroll down (10 lines)        |
-| `g`             | Jump to top                   |
-| `G`             | Jump to bottom                |
-| `s`             | Toggle split with raw source  |
-| `←` / `→`       | Switch tabs (when multiple files are open) |
-| `Esc` / `p`     | Exit preview                  |
-
-## Modes
-
-### Normal Mode
-
-Default mode for navigating and viewing query results. Use arrow keys or Vim-style navigation to browse through results.
-
-### Query Mode
-
-Activated by pressing `:`. Type your mq query and press Enter to execute. The query is evaluated in real-time as you type.
-
-### Tree View Mode
-
-Activated by pressing `t`. Displays the Markdown document structure as an expandable tree, showing the hierarchy of headings, lists, and other elements.
-
-### Preview Mode
-
-Activated by pressing `p`. Renders the active document's Markdown source close to its final look - styled headings, emphasis, lists, blockquotes, code blocks, tables, and links - instead of raw Markdown syntax. Press `s` to split the view and show the raw source alongside the rendered preview.
-
-### Search Mode
-
-Activated by pressing `/` from normal mode or tree view mode. Jumps the selection to the nearest match as you type; the search is scoped to whichever mode it was started from (results list or tree).
-
-### Favorites Mode
-
-Activated by pressing `F`. Browse, run, and delete queries you've previously saved with `S`.
-
-### Help Mode
-
-Activated by pressing `?` or `F1`. Displays all available keyboard shortcuts and commands.
-
-## Features in Detail
-
-### Real-time Query Execution
-
-Queries are executed as you type, providing immediate feedback and results.
-
-### Detail View
-
-Press `d` to toggle between list view and split view. In split view, the left pane shows the result list while the right pane displays detailed information about the selected item.
-
-### Query History
-
-All executed queries are saved in history. Use `↑` and `↓` in query mode to navigate through previous queries.
-
-### Clipboard Support
-
-Press `y` to copy the current query results to your system clipboard in Markdown format.
-
-### Tree Visualization
-
-The tree view mode provides a visual representation of your Markdown document's structure, with color-coded elements:
-
-- 🔵 **Blue**: Headings
-- 🟢 **Green**: Lists
-- 🔴 **Red**: Math expressions
-- 🟣 **Magenta**: Links
-- 🟡 **Yellow**: Images
-- 🔵 **Cyan**: Code blocks
-
-### Watch Mode
-
-Run with `--watch` to keep open files in sync with disk. This is handy when
-editing a Markdown file in another editor while exploring it with `mq-tui` -
-save your changes and they show up immediately, with the current query
-re-applied to the updated content.
+Press `?` or `F1` at any time in the app for the complete, mode-specific list of keyboard shortcuts.
 
 ## Configuration
 
 `mq-tui` works out of the box with sensible defaults. The UI adapts to your terminal's color scheme and size.
-
-Favorite queries saved with `S` are stored in `~/.config/mq-tui/queries.toml`
-(honoring `XDG_CONFIG_HOME` on Linux/macOS, or `%APPDATA%\mq-tui` on Windows).
 
 ## Related Projects
 
@@ -352,10 +205,16 @@ Favorite queries saved with `S` are stored in `~/.config/mq-tui/queries.toml`
 - [mq-view](https://github.com/harehare/mq-view) - Markdown viewer with syntax highlighting
 - [mqlang.org](https://mqlang.org) - Documentation and language reference
 
+## Support
+
+- 🐛 [Report bugs](https://github.com/harehare/mq-tui/issues/new)
+- 💡 [Request features](https://github.com/harehare/mq-tui/issues/new)
+- ⭐ [Star the project](https://github.com/harehare/mq-tui) if you find it useful!
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit issues or pull requests.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -182,18 +182,109 @@ Once in the TUI, press `:` to enter query mode and try these queries:
 
 ## Key Bindings
 
-| Key         | Action                      |
-| ----------- | --------------------------- |
-| `:`         | Enter query mode            |
-| `t`         | Toggle tree view            |
-| `p`         | Toggle rendered preview     |
-| `d`         | Toggle detail view          |
-| `y` / `Y`   | Copy results / selected row |
-| `o`         | Open a file as a new tab    |
-| `?` / `F1`  | Show the full help screen   |
-| `q` / `Esc` | Quit the application        |
+Press `?` or `F1` at any time in the app for this same list, in context.
 
-Press `?` or `F1` at any time in the app for the complete, mode-specific list of keyboard shortcuts.
+### Normal Mode
+
+| Key                 | Action                                     |
+| ------------------- | ------------------------------------------ |
+| `q` / `Esc`         | Quit the application                       |
+| `:`                 | Enter query mode                           |
+| `?` / `F1`          | Show help screen                           |
+| `t`                 | Toggle tree view mode                      |
+| `p`                 | Toggle rendered preview mode               |
+| `s`                 | Toggle sidebar (headers)                   |
+| `d`                 | Toggle detail view for selected item       |
+| `y`                 | Copy results to clipboard                  |
+| `Y`                 | Copy selected row to clipboard             |
+| `/`                 | Incremental search within results          |
+| `n` / `N`           | Repeat last search forward/backward        |
+| `S`                 | Save current query as a favorite           |
+| `F`                 | Browse saved (favorite) queries            |
+| `Ctrl+L`            | Clear current query                        |
+| `o`                 | Open a file as a new tab                   |
+| `←` / `→`           | Switch tabs (when multiple files are open) |
+| `Tab` / `Shift+Tab` | Switch tabs (when multiple files are open) |
+
+### Navigation
+
+| Key        | Action               |
+| ---------- | -------------------- |
+| `↑` / `k`  | Move up              |
+| `↓` / `j`  | Move down            |
+| `PageUp`   | Page up (10 items)   |
+| `PageDown` | Page down (10 items) |
+| `Home`     | Jump to first item   |
+| `End`      | Jump to last item    |
+
+### Query Mode
+
+| Key                    | Action                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `Enter`                | Execute query and return to normal mode                                        |
+| `Esc`                  | Exit query mode without executing                                              |
+| `↑` / `↓`              | Navigate query history                                                         |
+| `←` / `→`              | Move cursor in query string                                                    |
+| `Home` / `End`         | Jump to start/end of query                                                     |
+| `Backspace` / `Delete` | Edit query text                                                                |
+| `Tab` / `Shift+Tab`    | Cycle forward/backward through completion suggestions (or switch tabs if none) |
+
+### Search Mode
+
+| Key                    | Action                                   |
+| ---------------------- | ---------------------------------------- |
+| `Enter`                | Confirm search, keep the new position    |
+| `Esc`                  | Cancel search, restore previous position |
+| `←` / `→`              | Move cursor in search string             |
+| `Home` / `End`         | Jump to start/end of search text         |
+| `Backspace` / `Delete` | Edit search text                         |
+
+### Favorites Mode
+
+| Key         | Action                    |
+| ----------- | ------------------------- |
+| `↑` / `k`   | Move up                   |
+| `↓` / `j`   | Move down                 |
+| `Enter`     | Run the selected query    |
+| `d`         | Delete the selected query |
+| `Esc` / `F` | Close the favorites list  |
+
+### Tree View Mode
+
+| Key               | Action                                     |
+| ----------------- | ------------------------------------------ |
+| `↑` / `k`         | Move up in tree                            |
+| `↓` / `j`         | Move down in tree                          |
+| `Enter` / `Space` | Expand/collapse node                       |
+| `/`               | Incremental search within the tree         |
+| `n` / `N`         | Repeat last search forward/backward        |
+| `←` / `→`         | Switch tabs (when multiple files are open) |
+| `Esc` / `t`       | Exit tree view                             |
+| `?` / `F1`        | Show help                                  |
+
+### Open File Mode
+
+| Key                    | Action                           |
+| ---------------------- | -------------------------------- |
+| `Enter`                | Open the typed path as a new tab |
+| `Esc`                  | Cancel                           |
+| `←` / `→`              | Move cursor in path string       |
+| `Home` / `End`         | Jump to start/end of path        |
+| `Backspace` / `Delete` | Edit path text                   |
+
+### Preview Mode
+
+| Key         | Action                                     |
+| ----------- | ------------------------------------------ |
+| `↑` / `k`   | Scroll up                                  |
+| `↓` / `j`   | Scroll down                                |
+| `PageUp`    | Scroll up (10 lines)                       |
+| `PageDown`  | Scroll down (10 lines)                     |
+| `g`         | Jump to top                                |
+| `G`         | Jump to bottom                             |
+| `s`         | Toggle split with raw source               |
+| `←` / `→`   | Switch tabs (when multiple files are open) |
+| `Esc` / `p` | Exit preview                               |
 
 ## Configuration
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use arboard::Clipboard;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseEventKind};
 use miette::IntoDiagnostic;
-use mq_lang::Engine;
+use mq_lang::{BUILTIN_FUNCTION_DOC, BUILTIN_SELECTOR_DOC, Engine};
 use mq_markdown::Markdown;
 use ratatui::prelude::*;
 use std::{
@@ -27,6 +27,12 @@ pub enum Mode {
     TreeView,
     OpenFile,
     Preview,
+    /// Incremental search ('/'), entered from Normal or TreeView mode.
+    Search,
+    /// Prompting for a name under which to save the current query.
+    SaveQuery,
+    /// Browsing/running/deleting saved (favorite) queries.
+    Favorites,
 }
 
 impl Display for Mode {
@@ -38,8 +44,18 @@ impl Display for Mode {
             Mode::TreeView => write!(f, "TREE VIEW"),
             Mode::OpenFile => write!(f, "OPEN FILE"),
             Mode::Preview => write!(f, "PREVIEW"),
+            Mode::Search => write!(f, "SEARCH"),
+            Mode::SaveQuery => write!(f, "SAVE QUERY"),
+            Mode::Favorites => write!(f, "FAVORITES"),
         }
     }
+}
+
+/// A named query saved to disk so it can be reused across sessions.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SavedQuery {
+    pub name: String,
+    pub query: String,
 }
 
 /// A single open Markdown document (tab).
@@ -209,6 +225,38 @@ pub struct App {
     watch: bool,
     /// Event-driven watcher (OS file system notifications) backing `watch`
     file_watcher: Option<FileWatcher>,
+    /// Current incremental search text (Mode::Search)
+    search_query: String,
+    /// Cursor position within `search_query`
+    search_cursor: usize,
+    /// Mode to return to when leaving Mode::Search (Normal or TreeView)
+    search_return_mode: Mode,
+    /// Selected index (in the active document's results, or the tree view)
+    /// recorded when entering Mode::Search, so Esc can restore it
+    search_origin_idx: usize,
+    /// Last committed search term, used by `n` / `N` to repeat the search
+    last_search: Option<String>,
+    /// Name being typed for the query currently being saved (Mode::SaveQuery)
+    save_query_name: String,
+    /// Cursor position within `save_query_name`
+    save_query_cursor: usize,
+    /// Queries saved across sessions (loaded from disk)
+    saved_queries: Vec<SavedQuery>,
+    /// Currently selected index in Mode::Favorites
+    favorites_selected: usize,
+    /// Show raw source side-by-side with the rendered preview (Mode::Preview)
+    preview_split: bool,
+    /// Active Tab-completion cycle, if the user is currently cycling through candidates
+    completion_cycle: Option<CompletionCycle>,
+}
+
+/// Tracks an in-progress Tab-completion cycle so repeated Tab presses step
+/// through the same candidate list instead of recomputing it against
+/// whatever text the previous candidate left behind.
+struct CompletionCycle {
+    start: usize,
+    matches: Vec<(String, String)>,
+    index: usize,
 }
 
 impl App {
@@ -263,6 +311,17 @@ impl App {
             preview_viewport_height: Cell::new(0),
             watch: false,
             file_watcher: None,
+            search_query: String::new(),
+            search_cursor: 0,
+            search_return_mode: Mode::Normal,
+            search_origin_idx: 0,
+            last_search: None,
+            save_query_name: String::new(),
+            save_query_cursor: 0,
+            saved_queries: crate::favorites::load(),
+            favorites_selected: 0,
+            preview_split: false,
+            completion_cycle: None,
         }
     }
 
@@ -392,6 +451,9 @@ impl App {
             Mode::TreeView => self.handle_tree_view_mode_event(event),
             Mode::OpenFile => self.handle_open_file_mode_event(event),
             Mode::Preview => self.handle_preview_mode_event(event),
+            Mode::Search => self.handle_search_mode_event(event),
+            Mode::SaveQuery => self.handle_save_query_mode_event(event),
+            Mode::Favorites => self.handle_favorites_mode_event(event),
         }
     }
 
@@ -459,6 +521,32 @@ impl App {
                     self.mode = Mode::OpenFile;
                     self.open_file_path.clear();
                     self.open_file_cursor = 0;
+                }
+                // Incremental search within the current results
+                (KeyCode::Char('/'), _) => {
+                    self.search_return_mode = Mode::Normal;
+                    self.search_origin_idx = self.active_doc().selected_idx;
+                    self.search_query.clear();
+                    self.search_cursor = 0;
+                    self.mode = Mode::Search;
+                }
+                // Repeat last search
+                (KeyCode::Char('n'), _) if self.last_search.is_some() => {
+                    self.repeat_search(true);
+                }
+                (KeyCode::Char('N'), _) if self.last_search.is_some() => {
+                    self.repeat_search(false);
+                }
+                // Save the current query under a name
+                (KeyCode::Char('S'), _) => {
+                    self.mode = Mode::SaveQuery;
+                    self.save_query_name.clear();
+                    self.save_query_cursor = 0;
+                }
+                // Browse saved (favorite) queries
+                (KeyCode::Char('F'), _) => {
+                    self.favorites_selected = 0;
+                    self.mode = Mode::Favorites;
                 }
                 // Switch tabs
                 (KeyCode::Right, _) | (KeyCode::Tab, _) => {
@@ -599,46 +687,52 @@ impl App {
                     self.query_pending = false;
                     self.exec_query();
                 }
-                // Switch tabs without leaving query mode
-                (KeyCode::Tab, _) => {
-                    self.next_tab();
-                }
-                (KeyCode::BackTab, _) => {
-                    self.prev_tab();
-                }
+                // Tab/Shift+Tab step forward/backward through completion
+                // candidates for the current word; falls back to switching
+                // tabs when there's nothing to complete.
+                (KeyCode::Tab, _) => self.cycle_completion(true),
+                (KeyCode::BackTab, _) => self.cycle_completion(false),
                 // Edit query
                 (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                    self.completion_cycle = None;
                     self.query.insert(self.cursor_position, c);
                     self.cursor_position += 1;
                     self.last_exec = Instant::now();
                     self.query_pending = true;
                 }
                 (KeyCode::Backspace, _) if self.cursor_position > 0 => {
+                    self.completion_cycle = None;
                     self.query.remove(self.cursor_position - 1);
                     self.cursor_position -= 1;
                     self.last_exec = Instant::now();
                     self.query_pending = true;
                 }
                 (KeyCode::Delete, _) if self.cursor_position < self.query.len() => {
+                    self.completion_cycle = None;
                     self.query.remove(self.cursor_position);
                     self.last_exec = Instant::now();
                     self.query_pending = true;
                 }
                 // Move cursor
                 (KeyCode::Left, _) if self.cursor_position > 0 => {
+                    self.completion_cycle = None;
                     self.cursor_position -= 1;
                 }
                 (KeyCode::Right, _) if self.cursor_position < self.query.len() => {
+                    self.completion_cycle = None;
                     self.cursor_position += 1;
                 }
                 (KeyCode::Home, _) => {
+                    self.completion_cycle = None;
                     self.cursor_position = 0;
                 }
                 (KeyCode::End, _) => {
+                    self.completion_cycle = None;
                     self.cursor_position = self.query.len();
                 }
                 // Navigate history
                 (KeyCode::Up, _) if !self.query_history.is_empty() => {
+                    self.completion_cycle = None;
                     match self.history_position {
                         None => {
                             self.history_position = Some(self.query_history.len() - 1);
@@ -653,6 +747,7 @@ impl App {
                     self.cursor_position = self.query.len();
                 }
                 (KeyCode::Down, _) => {
+                    self.completion_cycle = None;
                     if let Some(pos) = self.history_position {
                         if pos < self.query_history.len() - 1 {
                             self.history_position = Some(pos + 1);
@@ -670,6 +765,46 @@ impl App {
         }
 
         Ok(())
+    }
+
+    /// Advance (or, if `forward` is false, step back) the Tab-completion
+    /// cycle for the word at the cursor, starting a new cycle if none is
+    /// active. Falls back to switching tabs if there's nothing to complete.
+    fn cycle_completion(&mut self, forward: bool) {
+        if self.completion_cycle.is_none() {
+            let matches = self.query_completions();
+            if matches.is_empty() {
+                if forward {
+                    self.next_tab();
+                } else {
+                    self.prev_tab();
+                }
+                return;
+            }
+            let (start, _) = Self::word_range_at_cursor(&self.query, self.cursor_position);
+            self.completion_cycle = Some(CompletionCycle {
+                start,
+                matches,
+                index: 0,
+            });
+        } else if let Some(cycle) = &mut self.completion_cycle {
+            let len = cycle.matches.len();
+            cycle.index = if forward {
+                (cycle.index + 1) % len
+            } else if cycle.index == 0 {
+                len - 1
+            } else {
+                cycle.index - 1
+            };
+        }
+
+        let cycle = self.completion_cycle.as_ref().unwrap();
+        let name = cycle.matches[cycle.index].0.clone();
+        let start = cycle.start;
+        self.query.replace_range(start..self.cursor_position, &name);
+        self.cursor_position = start + name.len();
+        self.last_exec = Instant::now();
+        self.query_pending = true;
     }
 
     fn handle_help_mode_event(&mut self, event: Event) -> miette::Result<()> {
@@ -758,6 +893,21 @@ impl App {
                 // Show help
                 (KeyCode::Char('?'), _) | (KeyCode::F(1), _) => {
                     self.mode = Mode::Help;
+                }
+                // Incremental search within the tree
+                (KeyCode::Char('/'), _) => {
+                    self.search_return_mode = Mode::TreeView;
+                    self.search_origin_idx =
+                        self.tree_view.as_ref().map(|t| t.selected_index()).unwrap_or(0);
+                    self.search_query.clear();
+                    self.search_cursor = 0;
+                    self.mode = Mode::Search;
+                }
+                (KeyCode::Char('n'), _) if self.last_search.is_some() => {
+                    self.repeat_search(true);
+                }
+                (KeyCode::Char('N'), _) if self.last_search.is_some() => {
+                    self.repeat_search(false);
                 }
                 _ => {}
             }
@@ -925,12 +1075,21 @@ impl App {
                 (KeyCode::Char('?'), _) | (KeyCode::F(1), _) => {
                     self.mode = Mode::Help;
                 }
+                // Toggle source/preview split
+                (KeyCode::Char('s'), _) => {
+                    self.preview_split = !self.preview_split;
+                }
                 _ => {}
             }
             self.clamp_preview_scroll();
         }
 
         Ok(())
+    }
+
+    /// Whether the preview shows raw source side-by-side with the rendered output
+    pub fn preview_split(&self) -> bool {
+        self.preview_split
     }
 
     /// Get the current preview scroll offset (in rendered lines)
@@ -1148,6 +1307,12 @@ impl App {
         self.cursor_position = position;
     }
 
+    /// Seed saved queries directly, bypassing disk load/save, for tests.
+    #[cfg(test)]
+    pub fn set_saved_queries(&mut self, queries: Vec<SavedQuery>) {
+        self.saved_queries = queries;
+    }
+
     /// Get the tree view, if available
     pub fn tree_view(&self) -> Option<&TreeView> {
         self.tree_view.as_ref()
@@ -1325,6 +1490,385 @@ impl App {
         }
 
         start // all invisible: stay put
+    }
+
+    /// Range of the identifier-like word (`[A-Za-z0-9_.]`) ending at `cursor`.
+    fn word_range_at_cursor(query: &str, cursor: usize) -> (usize, usize) {
+        let cursor = cursor.min(query.len());
+        let mut start = cursor;
+        while start > 0 {
+            let c = query[..start].chars().last().unwrap();
+            if c.is_alphanumeric() || c == '_' || c == '.' {
+                start -= c.len_utf8();
+            } else {
+                break;
+            }
+        }
+        (start, cursor)
+    }
+
+    /// Completion candidates (name, description) for the word at the cursor:
+    /// selectors (`.h`, ...) if it starts with `.`, else builtin functions.
+    pub fn query_completions(&self) -> Vec<(String, String)> {
+        let (start, end) = Self::word_range_at_cursor(&self.query, self.cursor_position);
+        let word = &self.query[start..end];
+        if word.is_empty() {
+            return Vec::new();
+        }
+
+        let mut matches: Vec<(String, String)> = if word.starts_with('.') {
+            BUILTIN_SELECTOR_DOC
+                .iter()
+                .filter(|(name, _)| name.starts_with(word))
+                .map(|(name, doc)| (name.to_string(), doc.description.to_string()))
+                .collect()
+        } else {
+            BUILTIN_FUNCTION_DOC
+                .iter()
+                .filter(|(name, _)| name.starts_with(word))
+                .map(|(name, doc)| (name.to_string(), doc.description.to_string()))
+                .collect()
+        };
+        matches.sort();
+        matches.truncate(8);
+        matches
+    }
+
+    /// Completion candidates to display: the active cycle's list while the
+    /// user is Tab-cycling, otherwise a fresh match against the cursor word.
+    pub fn active_completions(&self) -> Vec<(String, String)> {
+        match &self.completion_cycle {
+            Some(cycle) => cycle.matches.clone(),
+            None => self.query_completions(),
+        }
+    }
+
+    /// Index within `active_completions()` that is currently selected.
+    pub fn completion_selected_index(&self) -> usize {
+        self.completion_cycle.as_ref().map_or(0, |c| c.index)
+    }
+
+    fn handle_search_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match (code, modifiers) {
+                (KeyCode::Esc, _) => {
+                    self.restore_search_origin();
+                    self.mode = self.search_return_mode;
+                }
+                (KeyCode::Enter, _) => {
+                    if !self.search_query.is_empty() {
+                        self.last_search = Some(self.search_query.clone());
+                    }
+                    self.mode = self.search_return_mode;
+                }
+                (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                    self.search_query.insert(self.search_cursor, c);
+                    self.search_cursor += 1;
+                    self.apply_incremental_search();
+                }
+                (KeyCode::Backspace, _) if self.search_cursor > 0 => {
+                    self.search_query.remove(self.search_cursor - 1);
+                    self.search_cursor -= 1;
+                    self.apply_incremental_search();
+                }
+                (KeyCode::Delete, _) if self.search_cursor < self.search_query.len() => {
+                    self.search_query.remove(self.search_cursor);
+                    self.apply_incremental_search();
+                }
+                (KeyCode::Left, _) if self.search_cursor > 0 => {
+                    self.search_cursor -= 1;
+                }
+                (KeyCode::Right, _) if self.search_cursor < self.search_query.len() => {
+                    self.search_cursor += 1;
+                }
+                (KeyCode::Home, _) => {
+                    self.search_cursor = 0;
+                }
+                (KeyCode::End, _) => {
+                    self.search_cursor = self.search_query.len();
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Re-search from the origin position as the search text changes.
+    fn apply_incremental_search(&mut self) {
+        if self.search_query.is_empty() {
+            self.restore_search_origin();
+            return;
+        }
+
+        match self.search_return_mode {
+            Mode::TreeView => {
+                if let Some(tree_view) = &mut self.tree_view
+                    && let Some(idx) =
+                        tree_view.find_match(self.search_origin_idx, true, &self.search_query)
+                {
+                    tree_view.set_selected_index(idx);
+                }
+            }
+            _ => {
+                let results = &self.active_doc().results;
+                if let Some(idx) =
+                    Self::find_match_idx(results, self.search_origin_idx, true, &self.search_query)
+                {
+                    self.active_doc_mut().selected_idx = idx;
+                }
+            }
+        }
+    }
+
+    /// Restore the selection to before Mode::Search was entered (Esc).
+    fn restore_search_origin(&mut self) {
+        match self.search_return_mode {
+            Mode::TreeView => {
+                if let Some(tree_view) = &mut self.tree_view {
+                    tree_view.set_selected_index(self.search_origin_idx);
+                }
+            }
+            _ => {
+                self.active_doc_mut().selected_idx = self.search_origin_idx;
+            }
+        }
+    }
+
+    /// `n` / `N`: jump to the next/previous match of `last_search`.
+    fn repeat_search(&mut self, forward: bool) {
+        let Some(term) = self.last_search.clone() else {
+            return;
+        };
+
+        // Step past the current position so we don't re-select the same match.
+        fn step(current: usize, len: usize, forward: bool) -> Option<usize> {
+            if len == 0 {
+                return None;
+            }
+            Some(if forward {
+                (current + 1) % len
+            } else if current == 0 {
+                len - 1
+            } else {
+                current - 1
+            })
+        }
+
+        match self.search_return_mode {
+            Mode::TreeView => {
+                if let Some(tree_view) = &mut self.tree_view
+                    && let Some(start) = step(tree_view.selected_index(), tree_view.items().len(), forward)
+                    && let Some(idx) = tree_view.find_match(start, forward, &term)
+                {
+                    tree_view.set_selected_index(idx);
+                }
+            }
+            _ => {
+                let results = &self.active_doc().results;
+                if let Some(start) = step(self.active_doc().selected_idx, results.len(), forward)
+                    && let Some(idx) = Self::find_match_idx(results, start, forward, &term)
+                {
+                    self.active_doc_mut().selected_idx = idx;
+                }
+            }
+        }
+    }
+
+    /// Nearest result containing `term` (case-insensitive) from `start`, wrapping.
+    fn find_match_idx(
+        results: &[mq_markdown::Node],
+        start: usize,
+        forward: bool,
+        term: &str,
+    ) -> Option<usize> {
+        let len = results.len();
+        if len == 0 || term.is_empty() {
+            return None;
+        }
+        let term_lower = term.to_lowercase();
+        let start = start.min(len - 1);
+        let mut idx = start;
+
+        for step in 0..len {
+            if step > 0 {
+                idx = if forward {
+                    (idx + 1) % len
+                } else if idx == 0 {
+                    len - 1
+                } else {
+                    idx - 1
+                };
+            }
+            let rendered = Markdown::new(vec![results[idx].clone()])
+                .to_string()
+                .to_lowercase();
+            if rendered.contains(&term_lower) {
+                return Some(idx);
+            }
+        }
+
+        None
+    }
+
+    /// Current incremental search text
+    pub fn search_query(&self) -> &str {
+        &self.search_query
+    }
+
+    /// Cursor position within the search text
+    pub fn search_cursor(&self) -> usize {
+        self.search_cursor
+    }
+
+    /// The last committed search term, if any (used to highlight matches)
+    pub fn last_search(&self) -> Option<&str> {
+        self.last_search.as_deref()
+    }
+
+    fn handle_save_query_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match (code, modifiers) {
+                (KeyCode::Esc, _) => {
+                    self.mode = Mode::Normal;
+                }
+                (KeyCode::Enter, _) => {
+                    let name = self.save_query_name.trim().to_string();
+                    if !name.is_empty() {
+                        self.saved_queries.retain(|q| q.name != name);
+                        self.saved_queries.push(SavedQuery {
+                            name,
+                            query: self.query.clone(),
+                        });
+                        if let Err(err) = crate::favorites::save(&self.saved_queries) {
+                            self.transient_error =
+                                Some(format!("Could not save query: {err}"));
+                        }
+                    }
+                    self.mode = Mode::Normal;
+                }
+                (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                    self.save_query_name.insert(self.save_query_cursor, c);
+                    self.save_query_cursor += 1;
+                }
+                (KeyCode::Backspace, _) if self.save_query_cursor > 0 => {
+                    self.save_query_name.remove(self.save_query_cursor - 1);
+                    self.save_query_cursor -= 1;
+                }
+                (KeyCode::Delete, _) if self.save_query_cursor < self.save_query_name.len() => {
+                    self.save_query_name.remove(self.save_query_cursor);
+                }
+                (KeyCode::Left, _) if self.save_query_cursor > 0 => {
+                    self.save_query_cursor -= 1;
+                }
+                (KeyCode::Right, _) if self.save_query_cursor < self.save_query_name.len() => {
+                    self.save_query_cursor += 1;
+                }
+                (KeyCode::Home, _) => {
+                    self.save_query_cursor = 0;
+                }
+                (KeyCode::End, _) => {
+                    self.save_query_cursor = self.save_query_name.len();
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_favorites_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers: _,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match code {
+                KeyCode::Esc | KeyCode::Char('F') => {
+                    self.mode = Mode::Normal;
+                }
+                KeyCode::Char('q') => {
+                    self.should_quit = true;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    if self.favorites_selected + 1 < self.saved_queries.len() {
+                        self.favorites_selected += 1;
+                    }
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.favorites_selected = self.favorites_selected.saturating_sub(1);
+                }
+                KeyCode::Enter => {
+                    if let Some(saved) = self.saved_queries.get(self.favorites_selected) {
+                        self.query = saved.query.clone();
+                        self.cursor_position = self.query.len();
+                        self.mode = Mode::Normal;
+                        self.exec_query();
+                    }
+                }
+                KeyCode::Char('d') if self.favorites_selected < self.saved_queries.len() => {
+                    self.saved_queries.remove(self.favorites_selected);
+                    if let Err(err) = crate::favorites::save(&self.saved_queries) {
+                        self.transient_error =
+                            Some(format!("Could not update saved queries: {err}"));
+                    }
+                    self.favorites_selected = self
+                        .favorites_selected
+                        .min(self.saved_queries.len().saturating_sub(1));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Text currently typed for the name of the query being saved
+    pub fn save_query_name(&self) -> &str {
+        &self.save_query_name
+    }
+
+    /// Cursor position within the save-query name input
+    pub fn save_query_cursor(&self) -> usize {
+        self.save_query_cursor
+    }
+
+    /// Saved (favorite) queries, in order
+    pub fn saved_queries(&self) -> &[SavedQuery] {
+        &self.saved_queries
+    }
+
+    /// Currently selected index in Mode::Favorites
+    pub fn favorites_selected(&self) -> usize {
+        self.favorites_selected
+    }
+
+    /// Mode to return to when leaving Mode::Search; also what it searches.
+    pub fn search_return_mode(&self) -> Mode {
+        self.search_return_mode
+    }
+
+    /// Search term to highlight/jump to: in-progress text, else last committed.
+    pub fn active_search_term(&self) -> Option<&str> {
+        if self.mode == Mode::Search {
+            Some(&self.search_query)
+        } else {
+            self.last_search.as_deref()
+        }
     }
 }
 #[cfg(test)]
@@ -2428,5 +2972,278 @@ mod tests {
         assert_eq!(app.active_doc_content(), "# Original\n");
 
         std::fs::remove_file(&file_path).ok();
+    }
+
+    fn key_press(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        })
+    }
+
+    fn key(code: KeyCode) -> Event {
+        key_press(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn test_query_completions_match_selector_prefix() {
+        let mut app = create_test_app();
+        app.set_query(".h".to_string());
+        app.set_cursor_position(2);
+
+        let completions = app.query_completions();
+        assert!(completions.iter().any(|(name, _)| name == ".h"));
+        assert!(completions.iter().all(|(name, _)| name.starts_with(".h")));
+    }
+
+    #[test]
+    fn test_query_completions_match_function_prefix() {
+        let mut app = create_test_app();
+        app.set_query("flat".to_string());
+        app.set_cursor_position(4);
+
+        let completions = app.query_completions();
+        assert!(completions.iter().any(|(name, _)| name == "flatten"));
+    }
+
+    #[test]
+    fn test_query_completions_empty_word_has_no_suggestions() {
+        let mut app = create_test_app();
+        app.set_query("select(.a) | ".to_string());
+        app.set_cursor_position(13);
+
+        assert!(app.query_completions().is_empty());
+    }
+
+    #[test]
+    fn test_tab_accepts_top_completion_in_query_mode() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query("flat".to_string());
+        app.set_cursor_position(4);
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+
+        assert_eq!(app.query(), "flatten");
+        assert_eq!(app.cursor_position(), "flatten".len());
+    }
+
+    #[test]
+    fn test_tab_cycles_through_multiple_completions() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query("base64".to_string());
+        app.set_cursor_position(6);
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64");
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64d");
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64url");
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64urld");
+
+        // Wraps back around to the first candidate.
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64");
+    }
+
+    #[test]
+    fn test_shift_tab_cycles_backward() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query("base64".to_string());
+        app.set_cursor_position(6);
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64");
+
+        // Backward from the first candidate wraps to the last.
+        app.handle_event(key(KeyCode::BackTab)).unwrap();
+        assert_eq!(app.query(), "base64urld");
+
+        app.handle_event(key(KeyCode::BackTab)).unwrap();
+        assert_eq!(app.query(), "base64url");
+    }
+
+    #[test]
+    fn test_typing_after_completion_starts_a_fresh_cycle() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query("base64".to_string());
+        app.set_cursor_position(6);
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64d");
+
+        for c in " fla".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+        assert_eq!(app.query(), "base64d fla");
+
+        // Cycling again should be based on the new word ("fla"), not the
+        // stale "base64*" candidate list from before.
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+        assert_eq!(app.query(), "base64d flatten");
+    }
+
+    #[test]
+    fn test_tab_switches_tabs_when_no_completion() {
+        let mut app = App::with_files(vec![
+            ("# One".to_string(), "one.md".to_string()),
+            ("# Two".to_string(), "two.md".to_string()),
+        ]);
+        app.set_mode(Mode::Query);
+        app.set_query("".to_string());
+
+        app.handle_event(key(KeyCode::Tab)).unwrap();
+
+        assert_eq!(app.active_doc_index(), 1);
+    }
+
+    fn create_app_for_search() -> App {
+        let mut app = App::new("# Alpha\n\nneedle here\n\n# Beta\n".to_string());
+        app.set_query(".".to_string());
+        app.exec_query();
+        app
+    }
+
+    #[test]
+    fn test_slash_enters_search_mode_from_normal() {
+        let mut app = create_app_for_search();
+        app.handle_event(key(KeyCode::Char('/'))).unwrap();
+        assert_eq!(app.mode(), Mode::Search);
+    }
+
+    #[test]
+    fn test_incremental_search_jumps_to_match() {
+        let mut app = create_app_for_search();
+        app.handle_event(key(KeyCode::Char('/'))).unwrap();
+
+        for c in "needle".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+
+        assert_eq!(app.selected_idx(), 1);
+    }
+
+    #[test]
+    fn test_search_esc_restores_original_selection() {
+        let mut app = create_app_for_search();
+        assert_eq!(app.selected_idx(), 0);
+
+        app.handle_event(key(KeyCode::Char('/'))).unwrap();
+        for c in "Beta".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+        assert_eq!(app.selected_idx(), 2);
+
+        app.handle_event(key(KeyCode::Esc)).unwrap();
+
+        assert_eq!(app.mode(), Mode::Normal);
+        assert_eq!(app.selected_idx(), 0);
+    }
+
+    #[test]
+    fn test_search_enter_commits_and_repeat_with_n() {
+        let mut app = App::new("# Alpha\n\nneedle one\n\nneedle two\n".to_string());
+        app.set_query(".".to_string());
+        app.exec_query();
+
+        app.handle_event(key(KeyCode::Char('/'))).unwrap();
+        for c in "needle".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_event(key(KeyCode::Enter)).unwrap();
+
+        assert_eq!(app.mode(), Mode::Normal);
+        assert_eq!(app.selected_idx(), 1);
+
+        app.handle_event(key(KeyCode::Char('n'))).unwrap();
+        assert_eq!(app.selected_idx(), 2);
+
+        app.handle_event(key_press(KeyCode::Char('N'), KeyModifiers::SHIFT))
+            .unwrap();
+        assert_eq!(app.selected_idx(), 1);
+    }
+
+    #[test]
+    fn test_tree_view_search_jumps_selection() {
+        let mut app = App::new("# Alpha\n\n## Needle Heading\n\n# Beta\n".to_string());
+        app.handle_event(key(KeyCode::Char('t'))).unwrap();
+        assert_eq!(app.mode(), Mode::TreeView);
+
+        app.handle_event(key(KeyCode::Char('/'))).unwrap();
+        assert_eq!(app.mode(), Mode::Search);
+        assert_eq!(app.search_return_mode(), Mode::TreeView);
+
+        for c in "Needle".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+        app.handle_event(key(KeyCode::Enter)).unwrap();
+
+        assert_eq!(app.mode(), Mode::TreeView);
+        let selected = app.tree_view().unwrap().get_selected_node().unwrap();
+        if let mq_markdown::Node::Heading(h) = selected {
+            let text: String = h.values.iter().map(|n| n.value()).collect();
+            assert!(text.contains("Needle Heading"));
+        } else {
+            panic!("expected the search to land on the heading node");
+        }
+    }
+
+    #[test]
+    fn test_favorites_navigation_and_enter_applies_query() {
+        let mut app = create_test_app();
+        app.set_saved_queries(vec![
+            SavedQuery {
+                name: "headings".to_string(),
+                query: ".h".to_string(),
+            },
+            SavedQuery {
+                name: "all".to_string(),
+                query: ".".to_string(),
+            },
+        ]);
+
+        app.handle_event(key(KeyCode::Char('F'))).unwrap();
+        assert_eq!(app.mode(), Mode::Favorites);
+        assert_eq!(app.favorites_selected(), 0);
+
+        app.handle_event(key(KeyCode::Char('j'))).unwrap();
+        assert_eq!(app.favorites_selected(), 1);
+
+        app.handle_event(key(KeyCode::Char('k'))).unwrap();
+        assert_eq!(app.favorites_selected(), 0);
+
+        app.handle_event(key(KeyCode::Enter)).unwrap();
+        assert_eq!(app.mode(), Mode::Normal);
+        assert_eq!(app.query(), ".h");
+    }
+
+    #[test]
+    fn test_save_query_mode_name_input_and_cancel() {
+        let mut app = create_test_app();
+        app.set_query(".h".to_string());
+
+        app.handle_event(key(KeyCode::Char('S'))).unwrap();
+        assert_eq!(app.mode(), Mode::SaveQuery);
+
+        for c in "my query".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+        assert_eq!(app.save_query_name(), "my query");
+
+        app.handle_event(key(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode(), Mode::Normal);
+        // Esc cancels without saving.
+        assert!(!app.saved_queries().iter().any(|q| q.name == "my query"));
     }
 }

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -1,0 +1,118 @@
+//! Persistence for named "favorite" queries, saved under the user's config
+//! directory so they can be reused across sessions.
+
+use crate::app::SavedQuery;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct FavoritesFile {
+    #[serde(default)]
+    query: Vec<SavedQuery>,
+}
+
+/// `<config dir>/mq-tui/queries.toml`, honoring `XDG_CONFIG_HOME`/`APPDATA`.
+fn config_path() -> Option<PathBuf> {
+    let dir = if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        PathBuf::from(xdg)
+    } else if cfg!(windows) {
+        PathBuf::from(std::env::var("APPDATA").ok()?)
+    } else {
+        PathBuf::from(std::env::var("HOME").ok()?).join(".config")
+    };
+    Some(dir.join("mq-tui").join("queries.toml"))
+}
+
+/// Load saved queries from disk, or an empty list if missing/unparseable.
+pub fn load() -> Vec<SavedQuery> {
+    let Some(path) = config_path() else {
+        return Vec::new();
+    };
+    load_from(&path)
+}
+
+/// Persist saved queries to disk, creating the config directory if needed.
+pub fn save(queries: &[SavedQuery]) -> std::io::Result<()> {
+    let Some(path) = config_path() else {
+        return Ok(());
+    };
+    save_to(&path, queries)
+}
+
+fn load_from(path: &PathBuf) -> Vec<SavedQuery> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    toml::from_str::<FavoritesFile>(&content)
+        .map(|f| f.query)
+        .unwrap_or_default()
+}
+
+fn save_to(path: &PathBuf, queries: &[SavedQuery]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = FavoritesFile {
+        query: queries.to_vec(),
+    };
+    let content = toml::to_string_pretty(&file)
+        .map_err(|err| std::io::Error::other(format!("Could not serialize queries: {err}")))?;
+    std::fs::write(path, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_serialization() {
+        let file = FavoritesFile {
+            query: vec![
+                SavedQuery {
+                    name: "headings".to_string(),
+                    query: ".h".to_string(),
+                },
+                SavedQuery {
+                    name: "rust code".to_string(),
+                    query: r#".code | select(.lang == "rust")"#.to_string(),
+                },
+            ],
+        };
+        let content = toml::to_string_pretty(&file).unwrap();
+        let parsed: FavoritesFile = toml::from_str(&content).unwrap();
+        assert_eq!(parsed.query.len(), 2);
+        assert_eq!(parsed.query[0].name, "headings");
+        assert_eq!(parsed.query[1].query, r#".code | select(.lang == "rust")"#);
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_empty() {
+        let _ = load();
+    }
+
+    #[test]
+    fn test_save_to_and_load_from_temp_file_roundtrip() {
+        let path = std::env::temp_dir().join(format!(
+            "mq-tui-test-{}-{:?}.toml",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let queries = vec![SavedQuery {
+            name: "headings".to_string(),
+            query: ".h".to_string(),
+        }];
+
+        save_to(&path, &queries).unwrap();
+        let loaded = load_from(&path);
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "headings");
+        assert_eq!(loaded[0].query, ".h");
+    }
+
+    #[test]
+    fn test_load_from_nonexistent_path_returns_empty() {
+        let path = std::env::temp_dir().join("mq-tui-test-does-not-exist.toml");
+        assert!(load_from(&path).is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod app;
 mod event;
+mod favorites;
 mod ui;
 mod util;
 mod watcher;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,32 @@ use ratatui::{
 };
 
 use crate::app::{App, Mode};
+use unicode_width::UnicodeWidthChar;
+
+/// Break `line` into chunks of at most `width` display columns, preserving
+/// all original characters/spacing exactly (no word-boundary reflow), so
+/// list rows stay fully visible instead of being clipped.
+pub(crate) fn wrap_to_width(line: &str, width: usize) -> Vec<String> {
+    if width == 0 || line.is_empty() {
+        return vec![line.to_string()];
+    }
+
+    let mut rows = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+
+    for ch in line.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if current_width + ch_width > width && !current.is_empty() {
+            rows.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+        current.push(ch);
+        current_width += ch_width;
+    }
+    rows.push(current);
+    rows
+}
 
 pub fn draw_ui(frame: &mut Frame, app: &App) {
     let show_tabs = app.document_count() > 1;
@@ -45,10 +71,19 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
     match app.mode() {
         Mode::Query => draw_query_input(frame, app, header_area),
         Mode::OpenFile => draw_open_file_input(frame, app, header_area),
+        Mode::Search => draw_search_input(frame, app, header_area),
+        Mode::SaveQuery => draw_save_query_input(frame, app, header_area),
         _ => draw_title_bar(frame, app, header_area),
     }
 
-    match app.mode() {
+    // While searching, keep showing the view the search started from.
+    let display_mode = if app.mode() == Mode::Search {
+        app.search_return_mode()
+    } else {
+        app.mode()
+    };
+
+    match display_mode {
         Mode::TreeView => {
             if let Some(tree_view) = app.tree_view() {
                 tree_view.render(frame, results_area);
@@ -56,6 +91,9 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
         }
         Mode::Preview => {
             draw_preview(frame, app, results_area);
+        }
+        Mode::Favorites => {
+            draw_favorites_list(frame, app, results_area);
         }
         _ => {
             // Show sidebar if enabled
@@ -110,8 +148,16 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
 
     draw_status_line(frame, app, status_area);
 
-    if let Some(error) = app.error_msg() {
+    // Query mode shows errors inline (in the query box) instead of a
+    // blocking popup, since they re-fire on every keystroke while typing.
+    if app.mode() != Mode::Query
+        && let Some(error) = app.error_msg()
+    {
         draw_error_popup(frame, error);
+    }
+
+    if app.mode() == Mode::Query {
+        draw_completions_popup(frame, app, header_area);
     }
 
     if app.mode() == Mode::Help {
@@ -165,11 +211,110 @@ fn draw_open_file_input(frame: &mut Frame, app: &App, area: Rect) {
     ));
 }
 
+fn draw_search_input(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title("Search (Enter to confirm, Esc to cancel)")
+        .borders(Borders::ALL);
+
+    let text = Paragraph::new(app.search_query())
+        .style(Style::default().fg(Color::Yellow))
+        .block(block);
+
+    frame.render_widget(text, area);
+
+    let cursor_x = app.search_cursor() as u16 + 1;
+    frame.set_cursor_position(Position::new(area.x + cursor_x, area.y + 1));
+}
+
+fn draw_save_query_input(frame: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .title(format!(
+            "Save query as (Enter to confirm, Esc to cancel) - {}",
+            app.query()
+        ))
+        .borders(Borders::ALL);
+
+    let text = Paragraph::new(app.save_query_name())
+        .style(Style::default().fg(Color::Yellow))
+        .block(block);
+
+    frame.render_widget(text, area);
+
+    let cursor_x = app.save_query_cursor() as u16 + 1;
+    frame.set_cursor_position(Position::new(area.x + cursor_x, area.y + 1));
+}
+
+fn draw_favorites_list(frame: &mut Frame, app: &App, area: Rect) {
+    let saved = app.saved_queries();
+    let block = Block::default()
+        .title("Favorites (Enter to run, d to delete, Esc to close)")
+        .borders(Borders::ALL);
+
+    if saved.is_empty() {
+        let text = Paragraph::new("No saved queries yet - press 'S' to save the current query")
+            .style(Style::default().fg(Color::DarkGray))
+            .block(block);
+        frame.render_widget(text, area);
+        return;
+    }
+
+    let wrap_width = area.width.saturating_sub(2).max(1) as usize;
+
+    let items: Vec<ListItem> = saved
+        .iter()
+        .enumerate()
+        .map(|(i, saved)| {
+            let is_selected = i == app.favorites_selected();
+            let style = if is_selected {
+                Style::default().fg(Color::Black).bg(Color::White)
+            } else {
+                Style::default()
+            };
+            let name_style = style
+                .add_modifier(Modifier::BOLD)
+                .fg(if is_selected { Color::Black } else { Color::Cyan });
+            let query_style = style.fg(if is_selected { Color::Black } else { Color::Gray });
+
+            let text = format!("{}  {}", saved.name, saved.query);
+            let name_len = saved.name.chars().count();
+            let lines: Vec<Line> = wrap_to_width(&text, wrap_width)
+                .iter()
+                .enumerate()
+                .map(|(seg_i, segment)| {
+                    if seg_i == 0 {
+                        let chars: Vec<char> = segment.chars().collect();
+                        let split_at = name_len.min(chars.len());
+                        let name_part: String = chars[..split_at].iter().collect();
+                        let rest_part: String = chars[split_at..].iter().collect();
+                        Line::from(vec![
+                            Span::styled(name_part, name_style),
+                            Span::styled(rest_part, query_style),
+                        ])
+                    } else {
+                        Line::from(Span::styled(segment.clone(), query_style))
+                    }
+                })
+                .collect();
+
+            ListItem::new(lines).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(block);
+    let mut state = ListState::default();
+    state.select(Some(app.favorites_selected()));
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
 fn draw_query_input(frame: &mut Frame, app: &App, area: Rect) {
-    let query_block = Block::default()
-        .title("Query")
-        .borders(Borders::ALL)
-        .style(Style::default());
+    let mut query_block = Block::default().title("Query").borders(Borders::ALL);
+
+    if let Some(error) = app.error_msg() {
+        query_block = query_block.title_bottom(
+            Line::from(Span::styled(error.to_string(), Style::default().fg(Color::Red)))
+                .alignment(Alignment::Left),
+        );
+    }
 
     let query_text = Paragraph::new(app.query())
         .style(Style::default().fg(Color::Yellow))
@@ -182,6 +327,55 @@ fn draw_query_input(frame: &mut Frame, app: &App, area: Rect) {
         area.x + cursor_x,
         area.y + 1, // +1 for block border
     ));
+}
+
+/// Completion suggestions popup under the query box; Tab accepts the first entry.
+fn draw_completions_popup(frame: &mut Frame, app: &App, header_area: Rect) {
+    let completions = app.active_completions();
+    if completions.is_empty() {
+        return;
+    }
+    let selected = app.completion_selected_index();
+
+    let frame_area = frame.area();
+    let height = (completions.len() as u16 + 2).min(10);
+    let y = header_area.y + header_area.height;
+    if y >= frame_area.height {
+        return;
+    }
+    let height = height.min(frame_area.height - y);
+    let area = Rect::new(header_area.x, y, header_area.width, height);
+
+    frame.render_widget(Clear, area);
+
+    let items: Vec<ListItem> = completions
+        .iter()
+        .enumerate()
+        .map(|(i, (name, description))| {
+            let style = if i == selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Cyan)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!(" {name} "), style),
+                Span::styled(format!(" {description}"), Style::default().fg(Color::Gray)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Tab/Shift+Tab to cycle"),
+    );
+
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, area, &mut state);
 }
 
 fn draw_results_list(frame: &mut Frame, app: &App, area: Rect) {
@@ -231,24 +425,28 @@ fn draw_results_list(frame: &mut Frame, app: &App, area: Rect) {
 
     let selected_end_line = selected_line + selected_content_lines;
 
+    let search_term = app.active_search_term().filter(|t| !t.is_empty());
+    let wrap_width = area.width.saturating_sub(2).max(1) as usize;
+
     let items: Vec<ListItem> = mq_markdown::Markdown::new(results.to_vec())
         .to_string()
         .lines()
         .enumerate()
         .map(|(i, value)| {
             let is_selected = i >= selected_line && i < selected_end_line;
-            let content = if is_markdown_header(value) {
-                Line::from(Span::styled(
-                    value.to_string(),
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD),
-                ))
+            let base_style = if is_markdown_header(value) {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
             } else {
-                Line::from(value.to_string())
+                Style::default()
             };
+            let lines: Vec<Line> = wrap_to_width(value, wrap_width)
+                .iter()
+                .map(|segment| Line::from(highlight_matches(segment, search_term, base_style)))
+                .collect();
 
-            ListItem::new(content).style(if is_selected {
+            ListItem::new(lines).style(if is_selected {
                 Style::default().fg(Color::Black).bg(Color::White)
             } else {
                 Style::default()
@@ -276,10 +474,38 @@ fn draw_preview(frame: &mut Frame, app: &App, area: Rect) {
     let max_scroll = total_lines.saturating_sub(inner_height as usize) as u16;
     let scroll = app.preview_scroll().min(max_scroll);
 
+    let hint = if app.preview_split() {
+        "s to unsplit"
+    } else {
+        "s to split with source"
+    };
     let title = format!(
-        "Preview - {} (↑/k ↓/j scroll, g/G top/bottom, p/Esc to exit)",
+        "Preview - {} (↑/k ↓/j scroll, g/G top/bottom, {hint}, p/Esc to exit)",
         app.filename().unwrap_or("untitled")
     );
+
+    let preview_area = if app.preview_split() {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+
+        let source_lines: Vec<Line> = app
+            .active_doc_content()
+            .lines()
+            .map(|l| Line::from(l.to_string()))
+            .collect();
+        let source_block = Block::default().title("Source").borders(Borders::ALL);
+        let source_paragraph = Paragraph::new(source_lines)
+            .block(source_block)
+            .wrap(Wrap { trim: false })
+            .scroll((scroll, 0));
+        frame.render_widget(source_paragraph, chunks[0]);
+
+        chunks[1]
+    } else {
+        area
+    };
 
     let block = Block::default().title(title).borders(Borders::ALL);
 
@@ -288,7 +514,42 @@ fn draw_preview(frame: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false })
         .scroll((scroll, 0));
 
-    frame.render_widget(paragraph, area);
+    frame.render_widget(paragraph, preview_area);
+}
+
+/// Style every case-insensitive occurrence of `term` in `line` distinctly.
+fn highlight_matches(line: &str, term: Option<&str>, base_style: Style) -> Vec<Span<'static>> {
+    let Some(term) = term else {
+        return vec![Span::styled(line.to_string(), base_style)];
+    };
+    let line_lower = line.to_lowercase();
+    let term_lower = term.to_lowercase();
+    let mut spans = Vec::new();
+    let mut pos = 0;
+
+    while let Some(offset) = line_lower[pos..].find(&term_lower) {
+        let match_start = pos + offset;
+        let match_end = match_start + term.len();
+        if match_start > pos {
+            spans.push(Span::styled(line[pos..match_start].to_string(), base_style));
+        }
+        spans.push(Span::styled(
+            line[match_start..match_end].to_string(),
+            base_style
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        pos = match_end;
+    }
+    if pos < line.len() {
+        spans.push(Span::styled(line[pos..].to_string(), base_style));
+    }
+    if spans.is_empty() {
+        spans.push(Span::styled(line.to_string(), base_style));
+    }
+
+    spans
 }
 
 /// Check if a line is a markdown header (starts with #)
@@ -378,22 +639,13 @@ fn draw_detail_view(frame: &mut Frame, app: &App, area: Rect) {
 fn draw_help_screen(frame: &mut Frame) {
     let area = frame.area();
 
-    let width = area.width.clamp(20, 60);
-    let height = area.height.clamp(15, 40);
-    let x = (area.width.saturating_sub(width)) / 2;
-    let y = (area.height.saturating_sub(height)) / 2;
-
-    let help_area = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, help_area);
-
     let help_block = Block::default()
         .title("Keyboard Controls")
         .borders(Borders::ALL)
         .border_type(BorderType::Double)
         .style(Style::default().bg(Color::Black));
 
-    let help_text = vec![
+    let left_column = vec![
         Line::from(vec![Span::styled(
             "Navigation",
             Style::default()
@@ -449,7 +701,61 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::styled("↑/↓", Style::default().fg(Color::Yellow)),
             Span::raw(" - Navigate query history"),
         ]),
+        Line::from(vec![
+            Span::styled("Tab/Shift+Tab", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Cycle completion suggestions"),
+        ]),
         Line::from(""),
+        Line::from(vec![Span::styled(
+            "Search",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::UNDERLINED),
+        )]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("/", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Search within results or tree"),
+        ]),
+        Line::from(vec![
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Confirm search"),
+        ]),
+        Line::from(vec![
+            Span::styled("Esc", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Cancel search"),
+        ]),
+        Line::from(vec![
+            Span::styled("n/N", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Repeat search forward/backward"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "Favorite Queries",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::UNDERLINED),
+        )]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("S", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Save current query"),
+        ]),
+        Line::from(vec![
+            Span::styled("F", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Browse saved queries"),
+        ]),
+        Line::from(vec![
+            Span::styled("Enter", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Run selected query"),
+        ]),
+        Line::from(vec![
+            Span::styled("d", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Delete selected query"),
+        ]),
+    ];
+
+    let right_column = vec![
         Line::from(vec![Span::styled(
             "Other Commands",
             Style::default()
@@ -562,17 +868,33 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::raw(" - Jump to top/bottom"),
         ]),
         Line::from(vec![
+            Span::styled("s", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Toggle split with raw source"),
+        ]),
+        Line::from(vec![
             Span::styled("Esc/p", Style::default().fg(Color::Yellow)),
             Span::raw(" - Exit preview"),
         ]),
     ];
 
-    let help_paragraph = Paragraph::new(help_text)
-        .block(help_block)
-        .style(Style::default())
-        .alignment(Alignment::Left);
+    let content_lines = left_column.len().max(right_column.len());
+    let width = area.width.clamp(30, 90);
+    let height = (content_lines as u16 + 2).clamp(15, area.height);
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let help_area = Rect::new(x, y, width, height);
 
-    frame.render_widget(help_paragraph, help_area);
+    frame.render_widget(Clear, help_area);
+    let inner = help_block.inner(help_area);
+    frame.render_widget(help_block, help_area);
+
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(inner);
+
+    frame.render_widget(Paragraph::new(left_column).alignment(Alignment::Left), columns[0]);
+    frame.render_widget(Paragraph::new(right_column).alignment(Alignment::Left), columns[1]);
 }
 
 fn draw_error_popup(frame: &mut Frame, error: &str) {
@@ -767,6 +1089,61 @@ mod tests {
                 .join("")
                 .contains("Results")
         );
+    }
+
+    #[test]
+    fn test_wrap_to_width_splits_long_line() {
+        let rows = wrap_to_width("abcdefghij", 4);
+        assert_eq!(rows, vec!["abcd", "efgh", "ij"]);
+    }
+
+    #[test]
+    fn test_wrap_to_width_short_line_unchanged() {
+        let rows = wrap_to_width("short", 40);
+        assert_eq!(rows, vec!["short"]);
+    }
+
+    #[test]
+    fn test_wrap_to_width_preserves_whitespace() {
+        // A hard, position-preserving wrap must never collapse or drop
+        // interior spaces (this would corrupt code/table indentation).
+        let rows = wrap_to_width("a    b", 3);
+        assert_eq!(rows.concat(), "a    b");
+    }
+
+    #[test]
+    fn test_wrap_to_width_empty_line() {
+        assert_eq!(wrap_to_width("", 10), vec![""]);
+    }
+
+    #[test]
+    fn test_draw_results_list_wraps_long_lines_instead_of_clipping() {
+        let mut terminal = Terminal::new(TestBackend::new(20, 24)).unwrap();
+        let mut app = App::new("".to_string());
+        app.set_results(vec![mq_markdown::Node::Text(mq_markdown::Text {
+            value: "This line is much longer than the twenty column width of the terminal"
+                .to_string(),
+            position: None,
+        })]);
+
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                draw_results_list(frame, &app, area);
+            })
+            .unwrap();
+
+        let backend = terminal.backend();
+        let content = backend
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .join("");
+
+        // The tail of the line must still be visible somewhere (wrapped to
+        // a later row), not silently dropped because it didn't fit on one row.
+        assert!(content.contains("terminal"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 
 use crate::app::{App, Mode};
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Break `line` into chunks of at most `width` display columns, preserving
 /// all original characters/spacing exactly (no word-boundary reflow), so
@@ -636,13 +636,26 @@ fn draw_detail_view(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(detail_text, area);
 }
 
+fn max_line_width(lines: &[Line]) -> u16 {
+    lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.width())
+                .sum::<usize>()
+        })
+        .max()
+        .unwrap_or(0) as u16
+}
+
 fn draw_help_screen(frame: &mut Frame) {
     let area = frame.area();
 
     let help_block = Block::default()
         .title("Keyboard Controls")
         .borders(Borders::ALL)
-        .border_type(BorderType::Double)
+        .border_type(BorderType::Plain)
         .style(Style::default().bg(Color::Black));
 
     let left_column = vec![
@@ -654,11 +667,11 @@ fn draw_help_screen(frame: &mut Frame) {
         )]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("↑/k", Style::default().fg(Color::Yellow)),
+            Span::styled("Up/k", Style::default().fg(Color::Yellow)),
             Span::raw(" - Move up"),
         ]),
         Line::from(vec![
-            Span::styled("↓/j", Style::default().fg(Color::Yellow)),
+            Span::styled("Down/j", Style::default().fg(Color::Yellow)),
             Span::raw(" - Move down"),
         ]),
         Line::from(vec![
@@ -698,7 +711,7 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::raw(" - Exit query mode"),
         ]),
         Line::from(vec![
-            Span::styled("↑/↓", Style::default().fg(Color::Yellow)),
+            Span::styled("Up/Down", Style::default().fg(Color::Yellow)),
             Span::raw(" - Navigate query history"),
         ]),
         Line::from(vec![
@@ -796,7 +809,7 @@ fn draw_help_screen(frame: &mut Frame) {
         )]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("←/→", Style::default().fg(Color::Yellow)),
+            Span::styled("Left/Right", Style::default().fg(Color::Yellow)),
             Span::raw(" - Switch tabs"),
         ]),
         Line::from(vec![
@@ -824,11 +837,11 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::raw(" - Toggle sidebar (headers)"),
         ]),
         Line::from(vec![
-            Span::styled("↑/k", Style::default().fg(Color::Yellow)),
+            Span::styled("Up/k", Style::default().fg(Color::Yellow)),
             Span::raw(" - Move up in tree"),
         ]),
         Line::from(vec![
-            Span::styled("↓/j", Style::default().fg(Color::Yellow)),
+            Span::styled("Down/j", Style::default().fg(Color::Yellow)),
             Span::raw(" - Move down in tree"),
         ]),
         Line::from(vec![
@@ -860,7 +873,7 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::raw(" - Toggle rendered preview"),
         ]),
         Line::from(vec![
-            Span::styled("↑/k ↓/j", Style::default().fg(Color::Yellow)),
+            Span::styled("Up/k Down/j", Style::default().fg(Color::Yellow)),
             Span::raw(" - Scroll preview"),
         ]),
         Line::from(vec![
@@ -877,8 +890,13 @@ fn draw_help_screen(frame: &mut Frame) {
         ]),
     ];
 
+    const COLUMN_GAP: u16 = 4;
+
+    let left_width = max_line_width(&left_column);
+    let right_width = max_line_width(&right_column);
+
     let content_lines = left_column.len().max(right_column.len());
-    let width = area.width.clamp(30, 90);
+    let width = (left_width + COLUMN_GAP + right_width + 2).clamp(30, area.width.max(30));
     let height = (content_lines as u16 + 2).clamp(15, area.height);
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
@@ -890,11 +908,15 @@ fn draw_help_screen(frame: &mut Frame) {
 
     let columns = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .constraints([
+            Constraint::Length(left_width),
+            Constraint::Length(COLUMN_GAP),
+            Constraint::Length(right_width),
+        ])
         .split(inner);
 
     frame.render_widget(Paragraph::new(left_column).alignment(Alignment::Left), columns[0]);
-    frame.render_widget(Paragraph::new(right_column).alignment(Alignment::Left), columns[1]);
+    frame.render_widget(Paragraph::new(right_column).alignment(Alignment::Left), columns[2]);
 }
 
 fn draw_error_popup(frame: &mut Frame, error: &str) {

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -8,11 +8,13 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use std::collections::HashMap;
 
 /// Render raw Markdown `content` into a list of styled lines suitable for
 /// display in a scrollable `Paragraph`.
 pub fn render_preview(content: &str) -> Vec<Line<'static>> {
     let src_lines: Vec<&str> = content.lines().collect();
+    let defs = scan_link_definitions(&src_lines);
     let mut lines = Vec::with_capacity(src_lines.len());
     let mut in_code_block = false;
     let mut code_fence = String::new();
@@ -71,6 +73,18 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
             continue;
         }
 
+        // Invisible in real Markdown; dimmed here to keep line counts in sync.
+        if parse_definition_line(trimmed).is_some() {
+            lines.push(Line::from(Span::styled(
+                raw.to_string(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+            i += 1;
+            continue;
+        }
+
         // Table header row, immediately followed by an alignment separator row.
         if raw.contains('|')
             && src_lines
@@ -82,6 +96,7 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
+                &defs,
             )));
             i += 1;
             continue;
@@ -97,7 +112,7 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
         }
 
         if raw.contains('|') && raw.trim().starts_with('|') {
-            lines.push(Line::from(table_row_spans(raw, Style::default())));
+            lines.push(Line::from(table_row_spans(raw, Style::default(), &defs)));
             i += 1;
             continue;
         }
@@ -112,6 +127,7 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
                 Style::default()
                     .fg(Color::Gray)
                     .add_modifier(Modifier::ITALIC),
+                &defs,
             ));
             lines.push(Line::from(spans));
             i += 1;
@@ -127,7 +143,7 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
                     Style::default().fg(Color::Cyan),
                 ));
             }
-            spans.extend(parse_inline(rest, Style::default()));
+            spans.extend(parse_inline(rest, Style::default(), &defs));
             lines.push(Line::from(spans));
             i += 1;
             continue;
@@ -139,11 +155,33 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
             continue;
         }
 
-        lines.push(Line::from(parse_inline(raw, Style::default())));
+        lines.push(Line::from(parse_inline(raw, Style::default(), &defs)));
         i += 1;
     }
 
     lines
+}
+
+/// Parse a `[label]: url` reference definition line, if `trimmed` is one.
+fn parse_definition_line(trimmed: &str) -> Option<(String, String)> {
+    let rest = trimmed.strip_prefix('[')?;
+    let close = rest.find(']')?;
+    let label = rest[..close].trim().to_string();
+    let after = rest[close + 1..].strip_prefix(':')?.trim_start();
+    let url_end = after.find(char::is_whitespace).unwrap_or(after.len());
+    let url = &after[..url_end];
+    if label.is_empty() || url.is_empty() {
+        return None;
+    }
+    Some((label.to_lowercase(), url.to_string()))
+}
+
+/// All `[label]: url` definitions in the document, keyed by lowercased label.
+fn scan_link_definitions(src_lines: &[&str]) -> HashMap<String, String> {
+    src_lines
+        .iter()
+        .filter_map(|line| parse_definition_line(line.trim_start()))
+        .collect()
 }
 
 fn fence_marker(trimmed: &str) -> Option<String> {
@@ -209,14 +247,14 @@ fn is_table_separator(line: &str) -> bool {
     })
 }
 
-fn table_row_spans(raw: &str, cell_style: Style) -> Vec<Span<'static>> {
+fn table_row_spans(raw: &str, cell_style: Style, defs: &HashMap<String, String>) -> Vec<Span<'static>> {
     let cells: Vec<&str> = raw.trim().trim_matches('|').split('|').collect();
     let mut spans = Vec::new();
     for (idx, cell) in cells.iter().enumerate() {
         if idx > 0 {
             spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
         }
-        spans.extend(parse_inline(cell.trim(), cell_style));
+        spans.extend(parse_inline(cell.trim(), cell_style, defs));
     }
     spans
 }
@@ -271,7 +309,7 @@ fn checkbox(s: &str) -> (Option<bool>, &str) {
 /// Render a single line of inline Markdown (emphasis, code spans, links,
 /// images, strikethrough) into styled spans, falling back to plain text for
 /// anything it doesn't recognize.
-fn parse_inline(text: &str, base: Style) -> Vec<Span<'static>> {
+fn parse_inline(text: &str, base: Style, defs: &HashMap<String, String>) -> Vec<Span<'static>> {
     let chars: Vec<char> = text.chars().collect();
     let len = chars.len();
     let mut spans = Vec::new();
@@ -291,14 +329,42 @@ fn parse_inline(text: &str, base: Style) -> Vec<Span<'static>> {
         }
 
         if chars[i] == '['
-            && let Some((label, _url, consumed)) = parse_link_like(&chars, i)
+            && let Some((label, url, consumed)) = parse_link_like(&chars, i)
         {
             flush(&mut buf, &mut spans, base);
-            spans.push(Span::styled(
-                label,
-                base.fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
-            ));
-            i += consumed;
+
+            if !url.is_empty() {
+                spans.push(Span::styled(
+                    label,
+                    base.fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
+                ));
+                i += consumed;
+                continue;
+            }
+
+            // No inline `(url)`: try reference-style `[text][ref]` / shortcut `[text]`.
+            let mut end = i + consumed;
+            let mut ref_label = label.clone();
+            if end < len
+                && chars[end] == '['
+                && let Some((r, _, ref_consumed)) = parse_link_like(&chars, end)
+            {
+                end += ref_consumed;
+                if !r.is_empty() {
+                    ref_label = r;
+                }
+            }
+
+            if defs.contains_key(&ref_label.to_lowercase()) {
+                spans.push(Span::styled(
+                    label,
+                    base.fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
+                ));
+                i = end;
+            } else {
+                spans.push(Span::styled(format!("[{label}]"), base));
+                i += consumed;
+            }
             continue;
         }
 
@@ -323,6 +389,7 @@ fn parse_inline(text: &str, base: Style) -> Vec<Span<'static>> {
             spans.extend(parse_inline(
                 &inner,
                 base.add_modifier(Modifier::CROSSED_OUT),
+                defs,
             ));
             i += consumed;
             continue;
@@ -335,7 +402,7 @@ fn parse_inline(text: &str, base: Style) -> Vec<Span<'static>> {
             && !inner.is_empty()
         {
             flush(&mut buf, &mut spans, base);
-            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::BOLD)));
+            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::BOLD), defs));
             i += consumed;
             continue;
         }
@@ -345,7 +412,7 @@ fn parse_inline(text: &str, base: Style) -> Vec<Span<'static>> {
             && !inner.is_empty()
         {
             flush(&mut buf, &mut spans, base);
-            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::ITALIC)));
+            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::ITALIC), defs));
             i += consumed;
             continue;
         }
@@ -531,5 +598,48 @@ mod tests {
         let lines = render_preview("a\n\nb");
         assert_eq!(lines.len(), 3);
         assert_eq!(line_text(&lines[1]), "");
+    }
+
+    #[test]
+    fn test_reference_style_link_resolves_to_definition() {
+        let lines = render_preview("See [mq][ref] for details.\n\n[ref]: https://example.com");
+        assert_eq!(line_text(&lines[0]), "See mq for details.");
+        let span = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "mq")
+            .unwrap();
+        assert!(span.style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn test_shortcut_reference_link_resolves_to_definition() {
+        let lines = render_preview("See [mq] for details.\n\n[mq]: https://example.com");
+        let span = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "mq")
+            .unwrap();
+        assert!(span.style.add_modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn test_undefined_bracket_renders_as_literal_text() {
+        let lines = render_preview("This is [not a link] in prose.");
+        assert_eq!(line_text(&lines[0]), "This is [not a link] in prose.");
+    }
+
+    #[test]
+    fn test_definition_line_rendered_dimmed_and_preserves_line_count() {
+        let lines = render_preview("a\n[ref]: https://example.com\nb");
+        assert_eq!(lines.len(), 3);
+        assert!(line_text(&lines[1]).contains("https://example.com"));
+    }
+
+    #[test]
+    fn test_preview_line_count_matches_source_line_count() {
+        let content = "# Title\n\nSome *text* with a [link](url).\n\n- item\n\n> quote\n";
+        let lines = render_preview(content);
+        assert_eq!(lines.len(), content.lines().count());
     }
 }

--- a/src/ui/treeview.rs
+++ b/src/ui/treeview.rs
@@ -271,6 +271,44 @@ impl TreeView {
         self.selected_index
     }
 
+    pub fn set_selected_index(&mut self, index: usize) {
+        if index < self.items.len() {
+            self.selected_index = index;
+        }
+    }
+
+    /// Nearest item whose display text contains `term` (case-insensitive) from `start`, wrapping.
+    pub fn find_match(&self, start: usize, forward: bool, term: &str) -> Option<usize> {
+        let len = self.items.len();
+        if len == 0 || term.is_empty() {
+            return None;
+        }
+        let term_lower = term.to_lowercase();
+        let start = start.min(len - 1);
+        let mut idx = start;
+
+        for step in 0..len {
+            if step > 0 {
+                idx = if forward {
+                    (idx + 1) % len
+                } else if idx == 0 {
+                    len - 1
+                } else {
+                    idx - 1
+                };
+            }
+            if self.items[idx]
+                .display_text
+                .to_lowercase()
+                .contains(&term_lower)
+            {
+                return Some(idx);
+            }
+        }
+
+        None
+    }
+
     pub fn items(&self) -> &[TreeItem] {
         &self.items
     }
@@ -280,6 +318,7 @@ impl TreeView {
     }
 
     pub fn render_with_title(&self, frame: &mut Frame, area: Rect, title: &str) {
+        let wrap_width = area.width.saturating_sub(2).max(1) as usize;
         let items: Vec<ListItem> = self
             .items
             .iter()
@@ -330,16 +369,17 @@ impl TreeView {
                 };
 
                 let full_content = format!("{}{}", indent, content);
-                let line = Line::from(vec![Span::styled(
-                    full_content,
-                    if i == self.selected_index {
-                        Style::default().fg(Color::Black).bg(Color::White)
-                    } else {
-                        Self::get_node_style(&tree_item.node)
-                    },
-                )]);
+                let style = if i == self.selected_index {
+                    Style::default().fg(Color::Black).bg(Color::White)
+                } else {
+                    Self::get_node_style(&tree_item.node)
+                };
+                let lines: Vec<Line> = crate::ui::wrap_to_width(&full_content, wrap_width)
+                    .into_iter()
+                    .map(|segment| Line::from(Span::styled(segment, style)))
+                    .collect();
 
-                ListItem::new(line)
+                ListItem::new(lines)
             })
             .collect();
 


### PR DESCRIPTION
Add several interactive UX improvements to the TUI:

- Query mode now shows Tab/Shift+Tab-cyclable completion suggestions and inline docs for mq selectors/functions (sourced from mq-lang's builtin docs), and shows parse errors inline instead of in a blocking popup.
- Named "favorite" queries can be saved (`S`) and browsed/run/deleted (`F`), persisted to ~/.config/mq-tui/queries.toml.
- Incremental search (`/`, `n`/`N`) jumps to and highlights matches in the results list or tree view, restoring the prior position on Esc.
- Preview mode can split (`s`) to show raw source alongside the rendered output, and now resolves reference-style links (`[text][ref]` / `[ref]: url`).
- Long lines in the results list, tree view, and favorites list are now wrapped to the terminal width instead of being clipped.
