### PR TITLE
feat(preview): richer rendering and pager-style navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1058,11 +1058,23 @@ impl App {
                 (KeyCode::Up, _) | (KeyCode::Char('k'), _) => {
                     self.preview_scroll = self.preview_scroll.saturating_sub(1);
                 }
-                (KeyCode::PageDown, _) => {
-                    self.preview_scroll = self.preview_scroll.saturating_add(10);
+                // Full page (less/vim-pager style: f/Space forward, b back)
+                (KeyCode::PageDown, _) | (KeyCode::Char('f'), _) | (KeyCode::Char(' '), _) => {
+                    let page = self.preview_page_lines();
+                    self.preview_scroll = self.preview_scroll.saturating_add(page);
                 }
-                (KeyCode::PageUp, _) => {
-                    self.preview_scroll = self.preview_scroll.saturating_sub(10);
+                (KeyCode::PageUp, _) | (KeyCode::Char('b'), _) => {
+                    let page = self.preview_page_lines();
+                    self.preview_scroll = self.preview_scroll.saturating_sub(page);
+                }
+                // Half page (less/vim-pager style: d down, u up)
+                (KeyCode::Char('d'), _) => {
+                    let half = (self.preview_page_lines() / 2).max(1);
+                    self.preview_scroll = self.preview_scroll.saturating_add(half);
+                }
+                (KeyCode::Char('u'), _) => {
+                    let half = (self.preview_page_lines() / 2).max(1);
+                    self.preview_scroll = self.preview_scroll.saturating_sub(half);
                 }
                 // Jump to top/bottom (vim-style)
                 (KeyCode::Char('g'), _) => {
@@ -1117,6 +1129,11 @@ impl App {
         let viewport = self.preview_viewport_height.get().saturating_sub(2).max(1) as usize;
         let max_scroll = total.saturating_sub(viewport) as u16;
         self.preview_scroll = self.preview_scroll.min(max_scroll);
+    }
+
+    /// Lines per page/half-page scroll, based on the last-drawn viewport height.
+    fn preview_page_lines(&self) -> u16 {
+        self.preview_viewport_height.get().saturating_sub(2).max(1)
     }
 
     /// Update results based on current sidebar selection
@@ -2900,6 +2917,38 @@ mod tests {
             state: crossterm::event::KeyEventState::NONE,
         }))
         .unwrap();
+        assert_eq!(app.preview_scroll(), 0);
+    }
+
+    #[test]
+    fn test_preview_mode_page_and_half_page_navigation() {
+        let content = (0..50)
+            .map(|n| format!("line {n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut app = App::new(content);
+        app.set_mode(Mode::Preview);
+        app.set_preview_viewport_height(22); // inner height = 20
+
+        let press = |code: KeyCode| {
+            Event::Key(KeyEvent {
+                code,
+                modifiers: KeyModifiers::NONE,
+                kind: crossterm::event::KeyEventKind::Press,
+                state: crossterm::event::KeyEventState::NONE,
+            })
+        };
+
+        app.handle_event(press(KeyCode::Char('d'))).unwrap();
+        assert_eq!(app.preview_scroll(), 10);
+
+        app.handle_event(press(KeyCode::Char('u'))).unwrap();
+        assert_eq!(app.preview_scroll(), 0);
+
+        app.handle_event(press(KeyCode::Char('f'))).unwrap();
+        assert_eq!(app.preview_scroll(), 20);
+
+        app.handle_event(press(KeyCode::Char('b'))).unwrap();
         assert_eq!(app.preview_scroll(), 0);
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,12 +3,12 @@ pub mod treeview;
 
 use ratatui::{
     Frame,
-    layout::{Alignment, Constraint, Direction, Layout, Position, Rect},
+    layout::{Alignment, Constraint, Direction, Layout, Margin, Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
-        Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph, Tabs,
-        Wrap,
+        Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph,
+        Scrollbar, ScrollbarOrientation, ScrollbarState, Tabs, Wrap,
     },
 };
 
@@ -479,8 +479,13 @@ fn draw_preview(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         "s to split with source"
     };
+    let percent = if max_scroll == 0 {
+        100
+    } else {
+        (scroll as u32 * 100 / max_scroll as u32).min(100)
+    };
     let title = format!(
-        "Preview - {} (↑/k ↓/j scroll, g/G top/bottom, {hint}, p/Esc to exit)",
+        "Preview - {} [{percent}%] (j/k scroll, u/d ½-page, b/f page, g/G top/bottom, {hint}, p/Esc to exit)",
         app.filename().unwrap_or("untitled")
     );
 
@@ -515,6 +520,20 @@ fn draw_preview(frame: &mut Frame, app: &App, area: Rect) {
         .scroll((scroll, 0));
 
     frame.render_widget(paragraph, preview_area);
+
+    if total_lines > inner_height as usize {
+        let mut scrollbar_state = ScrollbarState::new(total_lines).position(scroll as usize);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓")),
+            preview_area.inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut scrollbar_state,
+        );
+    }
 }
 
 /// Style every case-insensitive occurrence of `term` in `line` distinctly.
@@ -875,6 +894,14 @@ fn draw_help_screen(frame: &mut Frame) {
         Line::from(vec![
             Span::styled("Up/k Down/j", Style::default().fg(Color::Yellow)),
             Span::raw(" - Scroll preview"),
+        ]),
+        Line::from(vec![
+            Span::styled("u/d", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Scroll half-page up/down"),
+        ]),
+        Line::from(vec![
+            Span::styled("b/f/Space", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Scroll full page up/down"),
         ]),
         Line::from(vec![
             Span::styled("g/G", Style::default().fg(Color::Yellow)),

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -9,6 +9,7 @@ use ratatui::{
     text::{Line, Span},
 };
 use std::collections::HashMap;
+use unicode_width::UnicodeWidthStr;
 
 /// Render raw Markdown `content` into a list of styled lines suitable for
 /// display in a scrollable `Paragraph`.
@@ -85,20 +86,41 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
             continue;
         }
 
-        // Table header row, immediately followed by an alignment separator row.
+        // Table header + separator: render the whole block so columns align.
         if raw.contains('|')
             && src_lines
                 .get(i + 1)
                 .is_some_and(|next| is_table_separator(next))
         {
-            lines.push(Line::from(table_row_spans(
-                raw,
+            let mut all_rows = vec![parse_table_cells(raw)];
+            let mut j = i + 2;
+            while j < src_lines.len() {
+                let candidate = src_lines[j];
+                if candidate.trim().is_empty()
+                    || !candidate.contains('|')
+                    || is_table_separator(candidate)
+                {
+                    break;
+                }
+                all_rows.push(parse_table_cells(candidate));
+                j += 1;
+            }
+
+            let widths = table_column_widths(&all_rows, &defs);
+            lines.push(render_table_row(
+                &all_rows[0],
+                &widths,
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
                 &defs,
-            )));
-            i += 1;
+            ));
+            lines.push(render_table_separator(&widths));
+            for row in &all_rows[1..] {
+                lines.push(render_table_row(row, &widths, Style::default(), &defs));
+            }
+
+            i = j;
             continue;
         }
 
@@ -118,15 +140,14 @@ pub fn render_preview(content: &str) -> Vec<Line<'static>> {
         }
 
         if let Some((level, rest)) = blockquote_prefix(raw) {
+            let color = blockquote_color(level);
             let mut spans = vec![Span::styled(
                 "┃ ".repeat(level.max(1)),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(color),
             )];
             spans.extend(parse_inline(
                 rest,
-                Style::default()
-                    .fg(Color::Gray)
-                    .add_modifier(Modifier::ITALIC),
+                Style::default().fg(color).add_modifier(Modifier::ITALIC),
                 &defs,
             ));
             lines.push(Line::from(spans));
@@ -259,6 +280,74 @@ fn table_row_spans(raw: &str, cell_style: Style, defs: &HashMap<String, String>)
     spans
 }
 
+fn parse_table_cells(raw: &str) -> Vec<String> {
+    raw.trim()
+        .trim_matches('|')
+        .split('|')
+        .map(|cell| cell.trim().to_string())
+        .collect()
+}
+
+/// Display width after Markdown syntax is stripped (e.g. `**bold**` -> `bold`).
+fn rendered_cell_width(cell: &str, defs: &HashMap<String, String>) -> usize {
+    parse_inline(cell, Style::default(), defs)
+        .iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
+}
+
+/// Widest rendered cell per column, across every row of a table block.
+fn table_column_widths(rows: &[Vec<String>], defs: &HashMap<String, String>) -> Vec<usize> {
+    let col_count = rows.iter().map(|row| row.len()).max().unwrap_or(0);
+    let mut widths = vec![0usize; col_count];
+    for row in rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(rendered_cell_width(cell, defs));
+        }
+    }
+    widths
+}
+
+fn render_table_row(
+    cells: &[String],
+    widths: &[usize],
+    cell_style: Style,
+    defs: &HashMap<String, String>,
+) -> Line<'static> {
+    let mut spans = Vec::new();
+    for (idx, cell) in cells.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+        }
+        let cell_spans = parse_inline(cell, cell_style, defs);
+        let rendered_width: usize = cell_spans
+            .iter()
+            .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+            .sum();
+        spans.extend(cell_spans);
+        let target = widths.get(idx).copied().unwrap_or(0);
+        if rendered_width < target {
+            spans.push(Span::styled(
+                " ".repeat(target - rendered_width),
+                cell_style,
+            ));
+        }
+    }
+    Line::from(spans)
+}
+
+fn render_table_separator(widths: &[usize]) -> Line<'static> {
+    let sep_style = Style::default().fg(Color::DarkGray);
+    let mut spans = Vec::new();
+    for (idx, width) in widths.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::styled("─┼─", sep_style));
+        }
+        spans.push(Span::styled("─".repeat((*width).max(1)), sep_style));
+    }
+    Line::from(spans)
+}
+
 fn blockquote_prefix(raw: &str) -> Option<(usize, &str)> {
     let mut rest = raw.trim_start();
     if !rest.starts_with('>') {
@@ -270,6 +359,15 @@ fn blockquote_prefix(raw: &str) -> Option<(usize, &str)> {
         rest = r.trim_start();
     }
     Some((level, rest))
+}
+
+/// Cycle blockquote color by nesting depth so quoted replies stand out.
+fn blockquote_color(level: usize) -> Color {
+    match level % 3 {
+        1 => Color::Gray,
+        2 => Color::Cyan,
+        _ => Color::Magenta,
+    }
 }
 
 fn list_item(raw: &str) -> Option<(usize, String, Option<bool>, &str)> {
@@ -577,6 +675,16 @@ mod tests {
         let lines = render_preview("| A | B |\n| - | - |\n| 1 | 2 |");
         assert_eq!(line_text(&lines[0]), "A │ B");
         assert_eq!(line_text(&lines[2]), "1 │ 2");
+    }
+
+    #[test]
+    fn test_table_columns_align_by_rendered_width() {
+        let lines =
+            render_preview("| Name | Note |\n| - | - |\n| **bold** | x |\n| a | much longer |");
+        // Row 1 is the separator (uses '┼', not '│'); compare the data rows.
+        let col_pos = |idx: usize| line_text(&lines[idx]).find('│').unwrap();
+        assert_eq!(col_pos(0), col_pos(2));
+        assert_eq!(col_pos(0), col_pos(3));
     }
 
     #[test]


### PR DESCRIPTION
Align table columns by rendered width across the whole block, color
nested blockquotes by depth, and add a scrollbar with scroll
percentage in the title. Add u/d half-page and b/f/space full-page
scrolling alongside the existing j/k and g/G keys.