### PR TITLE
feat: add command palette, themes, and resizable panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Interactive terminal interface for querying and manipulating Markdown content
 - 📖 **Detail View** - Inspect individual elements in depth
 - 🔄 **Query History** - Navigate through previous queries
 - 🎯 **fx-inspired UX** - Familiar interface for JSON query tool users
+- 🕹️ **Command Palette** - Fuzzy-searchable list of app actions (`Ctrl+K`)
+- 🌗 **Themes** - Dark (default) and light color themes for different terminal backgrounds
+- 💡 **Key-Hint Bar** - Persistent, mode-specific key hints folded into the status line (toggleable)
+- ✨ **Inline Completion** - Ghost-text suggestion for the top query completion as you type
 
 ## Installation
 
@@ -109,6 +113,8 @@ Press `t` to display the Markdown document structure as an expandable tree, show
 - 🟡 **Yellow**: Images
 - 🔵 **Cyan**: Code blocks
 
+The tree's title bar shows a breadcrumb trail (e.g. `# Intro › List › Text: ...`) for the selected node's ancestors, so it's easy to tell where you are in a deeply nested document.
+
 ### Rendered Preview
 
 Press `p` to switch to a rendered preview of the active document - headings, bold/italic text, lists, blockquotes, code blocks, tables, and links are styled to look close to their final rendered form instead of raw Markdown syntax. Use `↑`/`k`, `↓`/`j`, `PageUp`/`PageDown`, or `g`/`G` to scroll, and press `p` or `Esc` to return to normal mode. Press `s` while in preview mode to split the view and show the raw Markdown source side-by-side with the rendered output, scrolling in sync.
@@ -181,9 +187,11 @@ Press `?` or `F1` at any time in the app for this same list, in context.
 | `S`                 | Save current query as a favorite           |
 | `F`                 | Browse saved (favorite) queries            |
 | `Ctrl+L`            | Clear current query                        |
+| `Ctrl+K`            | Open command palette                       |
 | `o`                 | Open a file as a new tab                   |
 | `←` / `→`           | Switch tabs (when multiple files are open) |
 | `Tab` / `Shift+Tab` | Switch tabs (when multiple files are open) |
+| `<` / `>`           | Resize the sidebar (when `s` is on), otherwise the detail split (when `d` is on) |
 
 ### Navigation
 
@@ -262,12 +270,27 @@ Press `?` or `F1` at any time in the app for this same list, in context.
 | `g`         | Jump to top                                |
 | `G`         | Jump to bottom                             |
 | `s`         | Toggle split with raw source               |
+| `<` / `>`   | Resize the source/preview split (when `s` is on) |
 | `←` / `→`   | Switch tabs (when multiple files are open) |
 | `Esc` / `p` | Exit preview                               |
 
+### Command Palette
+
+Press `Ctrl+K` from Normal mode to open a searchable list of app actions - handy when you don't remember a key binding. Type to filter, `↑`/`↓` (or `Ctrl+P`/`Ctrl+N`) to move the selection, `Enter` to run it, `Esc` to close.
+
 ## Configuration
 
-`mq-tui` works out of the box with sensible defaults. The UI adapts to your terminal's color scheme and size.
+`mq-tui` works out of the box with sensible defaults. Settings are read from `<config dir>/mq-tui/config.toml` (`~/.config/mq-tui/config.toml` on Linux/macOS, honoring `XDG_CONFIG_HOME`; `%APPDATA%\mq-tui\config.toml` on Windows):
+
+```toml
+# Show mode-specific key hints on the left side of the status line (default: true)
+show_hint_bar = true
+
+# Color theme: "dark" (default) or "light"
+theme = "dark"
+```
+
+Both settings can also be overridden for a single run with `--no-hints` and `--theme <dark|light>`, without touching the file.
 
 ## Related Projects
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,9 @@ use std::{
 };
 
 use crate::{
+    config::{Config, ThemeName},
     event::{EventHandler, EventHandlerExt},
+    theme::Theme,
     ui::{draw_ui, preview, treeview::TreeView},
     util,
     watcher::{self, FileWatcher},
@@ -33,6 +35,8 @@ pub enum Mode {
     SaveQuery,
     /// Browsing/running/deleting saved (favorite) queries.
     Favorites,
+    /// Fuzzy-searchable list of app actions (opened with Ctrl+K).
+    CommandPalette,
 }
 
 impl Display for Mode {
@@ -47,8 +51,109 @@ impl Display for Mode {
             Mode::Search => write!(f, "SEARCH"),
             Mode::SaveQuery => write!(f, "SAVE QUERY"),
             Mode::Favorites => write!(f, "FAVORITES"),
+            Mode::CommandPalette => write!(f, "COMMAND PALETTE"),
         }
     }
+}
+
+/// A command palette entry, backed by the keypress that already implements it in Normal mode.
+pub struct PaletteAction {
+    pub label: &'static str,
+    pub description: &'static str,
+    key: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+const PALETTE_ACTIONS: &[PaletteAction] = &[
+    PaletteAction {
+        label: "Query",
+        description: "Enter query mode",
+        key: KeyCode::Char(':'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Tree view",
+        description: "Toggle tree view mode",
+        key: KeyCode::Char('t'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Preview",
+        description: "Toggle rendered preview mode",
+        key: KeyCode::Char('p'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Sidebar",
+        description: "Toggle sidebar (headers)",
+        key: KeyCode::Char('s'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Detail view",
+        description: "Toggle detail view for the selected item",
+        key: KeyCode::Char('d'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Copy results",
+        description: "Copy all results to the clipboard",
+        key: KeyCode::Char('y'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Copy selected row",
+        description: "Copy the selected row to the clipboard",
+        key: KeyCode::Char('Y'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Search",
+        description: "Incremental search within results",
+        key: KeyCode::Char('/'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Save query",
+        description: "Save the current query as a favorite",
+        key: KeyCode::Char('S'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Favorites",
+        description: "Browse saved (favorite) queries",
+        key: KeyCode::Char('F'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Open file",
+        description: "Open a file as a new tab",
+        key: KeyCode::Char('o'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Clear query",
+        description: "Clear the current query",
+        key: KeyCode::Char('l'),
+        modifiers: KeyModifiers::CONTROL,
+    },
+    PaletteAction {
+        label: "Help",
+        description: "Show the keyboard shortcuts help screen",
+        key: KeyCode::Char('?'),
+        modifiers: KeyModifiers::NONE,
+    },
+    PaletteAction {
+        label: "Quit",
+        description: "Quit the application",
+        key: KeyCode::Char('q'),
+        modifiers: KeyModifiers::NONE,
+    },
+];
+
+/// Case-insensitive substring match.
+fn fuzzy_match(haystack: &str, needle: &str) -> bool {
+    needle.is_empty() || haystack.to_lowercase().contains(&needle.to_lowercase())
 }
 
 /// A named query saved to disk so it can be reused across sessions.
@@ -251,6 +356,19 @@ pub struct App {
     preview_split: bool,
     /// Active Tab-completion cycle, if the user is currently cycling through candidates
     completion_cycle: Option<CompletionCycle>,
+    /// Persisted UI settings (theme, hint bar visibility)
+    config: Config,
+    /// Split ratio (left pane percent) for the results/detail split view
+    detail_split_percent: u16,
+    /// Split ratio (source pane percent) for the preview/source split view
+    preview_split_percent: u16,
+    sidebar_split_percent: u16,
+    /// Current filter text typed in Mode::CommandPalette
+    palette_query: String,
+    /// Cursor position within `palette_query`
+    palette_cursor: usize,
+    /// Currently selected index among the filtered palette actions
+    palette_selected: usize,
 }
 
 /// Tracks an in-progress Tab-completion cycle so repeated Tab presses step
@@ -326,6 +444,13 @@ impl App {
             favorites_selected: 0,
             preview_split: false,
             completion_cycle: None,
+            config: crate::config::load(),
+            detail_split_percent: 40,
+            preview_split_percent: 50,
+            sidebar_split_percent: 20,
+            palette_query: String::new(),
+            palette_cursor: 0,
+            palette_selected: 0,
         }
     }
 
@@ -458,6 +583,7 @@ impl App {
             Mode::Search => self.handle_search_mode_event(event),
             Mode::SaveQuery => self.handle_save_query_mode_event(event),
             Mode::Favorites => self.handle_favorites_mode_event(event),
+            Mode::CommandPalette => self.handle_command_palette_mode_event(event),
         }
     }
 
@@ -552,6 +678,25 @@ impl App {
                 (KeyCode::Char('F'), _) => {
                     self.favorites_selected = 0;
                     self.mode = Mode::Favorites;
+                }
+                // Open the command palette
+                (KeyCode::Char('k'), KeyModifiers::CONTROL) => {
+                    self.palette_query.clear();
+                    self.palette_cursor = 0;
+                    self.palette_selected = 0;
+                    self.mode = Mode::CommandPalette;
+                }
+                (KeyCode::Char('<'), _) if self.show_tree_sidebar => {
+                    self.adjust_sidebar_split(-5);
+                }
+                (KeyCode::Char('>'), _) if self.show_tree_sidebar => {
+                    self.adjust_sidebar_split(5);
+                }
+                (KeyCode::Char('<'), _) if self.show_detail => {
+                    self.adjust_detail_split(-5);
+                }
+                (KeyCode::Char('>'), _) if self.show_detail => {
+                    self.adjust_detail_split(5);
                 }
                 // Switch tabs
                 (KeyCode::Right, _) | (KeyCode::Tab, _) => {
@@ -824,6 +969,105 @@ impl App {
         Ok(())
     }
 
+    /// Palette actions whose label or description fuzzy-matches `palette_query`.
+    pub fn filtered_palette_actions(&self) -> Vec<&'static PaletteAction> {
+        PALETTE_ACTIONS
+            .iter()
+            .filter(|action| {
+                fuzzy_match(action.label, &self.palette_query)
+                    || fuzzy_match(action.description, &self.palette_query)
+            })
+            .collect()
+    }
+
+    pub fn palette_query(&self) -> &str {
+        &self.palette_query
+    }
+
+    pub fn palette_cursor(&self) -> usize {
+        self.palette_cursor
+    }
+
+    pub fn palette_selected(&self) -> usize {
+        self.palette_selected
+    }
+
+    /// Replays the action's keypress through the normal-mode handler, so
+    /// behavior isn't duplicated between the palette and key bindings.
+    fn run_palette_action(&mut self, action: &PaletteAction) -> miette::Result<()> {
+        self.mode = Mode::Normal;
+        self.handle_normal_mode_event(Event::Key(KeyEvent::new(action.key, action.modifiers)))
+    }
+
+    fn handle_command_palette_mode_event(&mut self, event: Event) -> miette::Result<()> {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match (code, modifiers) {
+                (KeyCode::Esc, _) => {
+                    self.mode = Mode::Normal;
+                }
+                (KeyCode::Enter, _) => {
+                    let matches = self.filtered_palette_actions();
+                    if let Some(action) = matches.get(self.palette_selected).copied() {
+                        self.run_palette_action(action)?;
+                    } else {
+                        self.mode = Mode::Normal;
+                    }
+                }
+                (KeyCode::Down, _) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
+                    let len = self.filtered_palette_actions().len();
+                    if len > 0 {
+                        self.palette_selected = (self.palette_selected + 1) % len;
+                    }
+                }
+                (KeyCode::Up, _) | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
+                    let len = self.filtered_palette_actions().len();
+                    if len > 0 {
+                        self.palette_selected = if self.palette_selected == 0 {
+                            len - 1
+                        } else {
+                            self.palette_selected - 1
+                        };
+                    }
+                }
+                (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                    self.palette_query.insert(self.palette_cursor, c);
+                    self.palette_cursor += 1;
+                    self.palette_selected = 0;
+                }
+                (KeyCode::Backspace, _) if self.palette_cursor > 0 => {
+                    self.palette_query.remove(self.palette_cursor - 1);
+                    self.palette_cursor -= 1;
+                    self.palette_selected = 0;
+                }
+                (KeyCode::Delete, _) if self.palette_cursor < self.palette_query.len() => {
+                    self.palette_query.remove(self.palette_cursor);
+                    self.palette_selected = 0;
+                }
+                (KeyCode::Left, _) if self.palette_cursor > 0 => {
+                    self.palette_cursor -= 1;
+                }
+                (KeyCode::Right, _) if self.palette_cursor < self.palette_query.len() => {
+                    self.palette_cursor += 1;
+                }
+                (KeyCode::Home, _) => {
+                    self.palette_cursor = 0;
+                }
+                (KeyCode::End, _) => {
+                    self.palette_cursor = self.palette_query.len();
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
     fn handle_tree_view_mode_event(&mut self, event: Event) -> miette::Result<()> {
         if let Event::Mouse(mouse_event) = event {
             match mouse_event.kind {
@@ -902,8 +1146,11 @@ impl App {
                 // Incremental search within the tree
                 (KeyCode::Char('/'), _) => {
                     self.search_return_mode = Mode::TreeView;
-                    self.search_origin_idx =
-                        self.tree_view.as_ref().map(|t| t.selected_index()).unwrap_or(0);
+                    self.search_origin_idx = self
+                        .tree_view
+                        .as_ref()
+                        .map(|t| t.selected_index())
+                        .unwrap_or(0);
                     self.search_query.clear();
                     self.search_cursor = 0;
                     self.mode = Mode::Search;
@@ -1096,6 +1343,13 @@ impl App {
                 (KeyCode::Char('s'), _) => {
                     self.preview_split = !self.preview_split;
                 }
+                // Adjust the source/preview split ratio
+                (KeyCode::Char('<'), _) if self.preview_split => {
+                    self.adjust_preview_split(-5);
+                }
+                (KeyCode::Char('>'), _) if self.preview_split => {
+                    self.adjust_preview_split(5);
+                }
                 _ => {}
             }
             self.clamp_preview_scroll();
@@ -1107,6 +1361,67 @@ impl App {
     /// Whether the preview shows raw source side-by-side with the rendered output
     pub fn preview_split(&self) -> bool {
         self.preview_split
+    }
+
+    /// The active color theme, derived from persisted config.
+    pub fn theme(&self) -> Theme {
+        Theme::from_name(self.config.theme)
+    }
+
+    pub fn theme_name(&self) -> ThemeName {
+        self.config.theme
+    }
+
+    /// Session-only theme override (e.g. `--theme`); does not touch config.toml.
+    pub fn set_theme_name(&mut self, name: ThemeName) {
+        self.config.theme = name;
+    }
+
+    /// Whether the persistent, mode-specific key-hint bar is shown above the status line.
+    pub fn show_hint_bar(&self) -> bool {
+        self.config.show_hint_bar
+    }
+
+    /// Session-only hint-bar override (e.g. `--no-hints`); does not touch config.toml.
+    pub fn set_show_hint_bar(&mut self, show: bool) {
+        self.config.show_hint_bar = show;
+    }
+
+    /// Percentage width of the results list in the results/detail split view.
+    pub fn detail_split_percent(&self) -> u16 {
+        self.detail_split_percent
+    }
+
+    /// Percentage width of the source pane in the preview/source split view.
+    pub fn preview_split_percent(&self) -> u16 {
+        self.preview_split_percent
+    }
+
+    pub fn sidebar_split_percent(&self) -> u16 {
+        self.sidebar_split_percent
+    }
+
+    /// Widen/narrow the results pane relative to the detail pane, in 5% steps.
+    fn adjust_detail_split(&mut self, delta: i16) {
+        self.detail_split_percent = self
+            .detail_split_percent
+            .saturating_add_signed(delta)
+            .clamp(15, 85);
+    }
+
+    /// Widen/narrow the source pane relative to the rendered preview, in 5% steps.
+    fn adjust_preview_split(&mut self, delta: i16) {
+        self.preview_split_percent = self
+            .preview_split_percent
+            .saturating_add_signed(delta)
+            .clamp(15, 85);
+    }
+
+    fn adjust_sidebar_split(&mut self, delta: i16) {
+        self.sidebar_split_percent = self
+            .sidebar_split_percent
+            .saturating_add_signed(delta)
+            .clamp(10, 50);
     }
 
     /// Get the current preview scroll offset (in rendered lines)
@@ -1570,6 +1885,26 @@ impl App {
         self.completion_cycle.as_ref().map_or(0, |c| c.index)
     }
 
+    /// Remaining characters of the top completion candidate, for inline
+    /// "ghost text". `None` unless the cursor is at the end of the query
+    /// (otherwise the suggestion would overlap text after the cursor).
+    pub fn ghost_suffix(&self) -> Option<String> {
+        if self.completion_cycle.is_some() || self.cursor_position != self.query.len() {
+            return None;
+        }
+        let (start, end) = Self::word_range_at_cursor(&self.query, self.cursor_position);
+        let word = &self.query[start..end];
+        if word.is_empty() {
+            return None;
+        }
+        let top = self.query_completions().into_iter().next()?;
+        if top.0.len() > word.len() {
+            Some(top.0[word.len()..].to_string())
+        } else {
+            None
+        }
+    }
+
     fn handle_search_mode_event(&mut self, event: Event) -> miette::Result<()> {
         if let Event::Key(KeyEvent {
             code,
@@ -1691,7 +2026,8 @@ impl App {
         match self.search_return_mode {
             Mode::TreeView => {
                 if let Some(tree_view) = &mut self.tree_view
-                    && let Some(start) = step(tree_view.selected_index(), tree_view.items().len(), forward)
+                    && let Some(start) =
+                        step(tree_view.selected_index(), tree_view.items().len(), forward)
                     && let Some(idx) = tree_view.find_match(start, forward, &term)
                 {
                     tree_view.set_selected_index(idx);
@@ -1699,7 +2035,8 @@ impl App {
             }
             _ => {
                 let results = &self.active_doc().results;
-                let start = step(self.active_doc().selected_idx, results.len(), forward).unwrap_or(0);
+                let start =
+                    step(self.active_doc().selected_idx, results.len(), forward).unwrap_or(0);
                 if let Some((doc_idx, idx)) = Self::find_match_across_tabs(
                     &self.documents,
                     self.active_doc,
@@ -1778,7 +2115,11 @@ impl App {
                 (start_doc + doc_count - step) % doc_count
             };
             let results = &documents[doc_idx].results;
-            let start = if forward { 0 } else { results.len().saturating_sub(1) };
+            let start = if forward {
+                0
+            } else {
+                results.len().saturating_sub(1)
+            };
             if let Some(idx) = Self::find_match_idx(results, start, forward, term) {
                 return Some((doc_idx, idx));
             }
@@ -1823,8 +2164,7 @@ impl App {
                             query: self.query.clone(),
                         });
                         if let Err(err) = crate::favorites::save(&self.saved_queries) {
-                            self.transient_error =
-                                Some(format!("Could not save query: {err}"));
+                            self.transient_error = Some(format!("Could not save query: {err}"));
                         }
                     }
                     self.mode = Mode::Normal;
@@ -3414,5 +3754,130 @@ mod tests {
         assert_eq!(app.mode(), Mode::Normal);
         // Esc cancels without saving.
         assert!(!app.saved_queries().iter().any(|q| q.name == "my query"));
+    }
+
+    #[test]
+    fn test_ctrl_k_opens_command_palette() {
+        let mut app = create_test_app();
+        app.handle_event(key_press(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .unwrap();
+        assert_eq!(app.mode(), Mode::CommandPalette);
+        assert!(!app.filtered_palette_actions().is_empty());
+    }
+
+    #[test]
+    fn test_command_palette_filters_by_fuzzy_match() {
+        let mut app = create_test_app();
+        app.handle_event(key_press(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .unwrap();
+
+        for c in "tree".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+
+        let matches = app.filtered_palette_actions();
+        assert!(matches.iter().any(|a| a.label == "Tree view"));
+        assert!(!matches.iter().any(|a| a.label == "Quit"));
+    }
+
+    #[test]
+    fn test_command_palette_enter_runs_action() {
+        let mut app = create_test_app();
+        app.handle_event(key_press(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .unwrap();
+        for c in "tree".chars() {
+            app.handle_event(key(KeyCode::Char(c))).unwrap();
+        }
+
+        app.handle_event(key(KeyCode::Enter)).unwrap();
+
+        assert_eq!(app.mode(), Mode::TreeView);
+    }
+
+    #[test]
+    fn test_command_palette_esc_cancels() {
+        let mut app = create_test_app();
+        app.handle_event(key_press(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .unwrap();
+        app.handle_event(key(KeyCode::Esc)).unwrap();
+        assert_eq!(app.mode(), Mode::Normal);
+    }
+
+    #[test]
+    fn test_ghost_suffix_suggests_top_completion_at_cursor_end() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query(".head".to_string());
+        app.set_cursor_position(5);
+
+        assert_eq!(app.ghost_suffix().as_deref(), Some("ing"));
+    }
+
+    #[test]
+    fn test_ghost_suffix_none_when_cursor_not_at_end() {
+        let mut app = create_test_app();
+        app.set_mode(Mode::Query);
+        app.set_query(".heading extra".to_string());
+        app.set_cursor_position(5);
+
+        assert_eq!(app.ghost_suffix(), None);
+    }
+
+    #[test]
+    fn test_detail_split_adjust_clamped() {
+        let mut app = create_test_app();
+        app.handle_event(key(KeyCode::Char('d'))).unwrap();
+        assert!(app.show_detail());
+        assert_eq!(app.detail_split_percent(), 40);
+
+        for _ in 0..20 {
+            app.handle_event(key(KeyCode::Char('>'))).unwrap();
+        }
+        assert_eq!(app.detail_split_percent(), 85);
+
+        for _ in 0..20 {
+            app.handle_event(key(KeyCode::Char('<'))).unwrap();
+        }
+        assert_eq!(app.detail_split_percent(), 15);
+    }
+
+    #[test]
+    fn test_sidebar_split_adjust_clamped() {
+        let mut app = create_test_app();
+        app.handle_event(key(KeyCode::Char('s'))).unwrap();
+        assert!(app.show_tree_sidebar());
+        assert_eq!(app.sidebar_split_percent(), 20);
+
+        for _ in 0..20 {
+            app.handle_event(key(KeyCode::Char('>'))).unwrap();
+        }
+        assert_eq!(app.sidebar_split_percent(), 50);
+
+        for _ in 0..20 {
+            app.handle_event(key(KeyCode::Char('<'))).unwrap();
+        }
+        assert_eq!(app.sidebar_split_percent(), 10);
+    }
+
+    #[test]
+    fn test_split_resize_prioritizes_sidebar_over_detail() {
+        let mut app = create_test_app();
+        app.handle_event(key(KeyCode::Char('s'))).unwrap();
+        app.handle_event(key(KeyCode::Char('d'))).unwrap();
+        assert!(app.show_tree_sidebar());
+        assert!(app.show_detail());
+
+        app.handle_event(key(KeyCode::Char('>'))).unwrap();
+
+        assert_eq!(app.sidebar_split_percent(), 25);
+        assert_eq!(app.detail_split_percent(), 40);
+    }
+
+    #[test]
+    fn test_theme_override_does_not_persist() {
+        let mut app = create_test_app();
+        assert_eq!(app.theme_name(), ThemeName::Dark);
+        app.set_theme_name(ThemeName::Light);
+        assert_eq!(app.theme_name(), ThemeName::Light);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,115 @@
+//! User-editable app settings (theme, hint bar visibility, ...), read from
+//! the user's config directory next to the favorite queries file. The app
+//! only reads this file; CLI flags override it for a single run.
+
+use std::path::PathBuf;
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+    clap::ValueEnum,
+)]
+#[serde(rename_all = "lowercase")]
+#[value(rename_all = "lowercase")]
+pub enum ThemeName {
+    #[default]
+    Dark,
+    Light,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct Config {
+    /// Whether to show the persistent, mode-specific key-hint bar above the status line.
+    pub show_hint_bar: bool,
+    /// Color theme applied to the UI.
+    pub theme: ThemeName,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            show_hint_bar: true,
+            theme: ThemeName::default(),
+        }
+    }
+}
+
+/// `<config dir>/mq-tui/config.toml`, honoring `XDG_CONFIG_HOME`/`APPDATA`.
+fn config_path() -> Option<PathBuf> {
+    let dir = if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        PathBuf::from(xdg)
+    } else if cfg!(windows) {
+        PathBuf::from(std::env::var("APPDATA").ok()?)
+    } else {
+        PathBuf::from(std::env::var("HOME").ok()?).join(".config")
+    };
+    Some(dir.join("mq-tui").join("config.toml"))
+}
+
+/// Load settings from disk, or defaults if missing/unparseable.
+pub fn load() -> Config {
+    let Some(path) = config_path() else {
+        return Config::default();
+    };
+    load_from(&path)
+}
+
+fn load_from(path: &PathBuf) -> Config {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Config::default();
+    };
+    toml::from_str(&content).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default();
+        assert!(config.show_hint_bar);
+        assert_eq!(config.theme, ThemeName::Dark);
+    }
+
+    #[test]
+    fn test_roundtrip_serialization() {
+        let config = Config {
+            show_hint_bar: false,
+            theme: ThemeName::Light,
+        };
+        let content = toml::to_string_pretty(&config).unwrap();
+        let parsed: Config = toml::from_str(&content).unwrap();
+        assert!(!parsed.show_hint_bar);
+        assert_eq!(parsed.theme, ThemeName::Light);
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_default() {
+        let path = std::env::temp_dir().join("mq-tui-test-config-does-not-exist.toml");
+        let config = load_from(&path);
+        assert!(config.show_hint_bar);
+    }
+
+    #[test]
+    fn test_load_from_partial_toml_fills_defaults() {
+        let path = std::env::temp_dir().join(format!(
+            "mq-tui-test-config-{}-{:?}.toml",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, "theme = \"light\"\n").unwrap();
+        let config = load_from(&path);
+        std::fs::remove_file(&path).ok();
+
+        assert!(config.show_hint_bar);
+        assert_eq!(config.theme, ThemeName::Light);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 mod app;
+mod config;
 mod event;
 mod favorites;
+mod theme;
 mod ui;
 mod util;
 mod watcher;
 
 pub use app::App;
 pub use app::Mode;
+pub use config::ThemeName;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use miette::{IntoDiagnostic, miette};
-use mq_tui::App;
+use mq_tui::{App, ThemeName};
 use std::fs;
 use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
@@ -29,6 +29,14 @@ struct Cli {
     /// Watch opened files and reload automatically when they change on disk
     #[arg(short, long)]
     watch: bool,
+
+    /// Color theme (overrides config.toml for this run)
+    #[arg(long, value_name = "THEME")]
+    theme: Option<ThemeName>,
+
+    /// Hide the persistent key-hint bar (overrides config.toml for this run)
+    #[arg(long)]
+    no_hints: bool,
 }
 
 fn main() -> miette::Result<()> {
@@ -61,6 +69,12 @@ fn main() -> miette::Result<()> {
 
     if cli.watch {
         app.set_watch(true);
+    }
+    if let Some(theme) = cli.theme {
+        app.set_theme_name(theme);
+    }
+    if cli.no_hints {
+        app.set_show_hint_bar(false);
     }
 
     app.run()?;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,88 @@
+//! Color palettes for the UI. `dark()` matches the original hardcoded colors;
+//! `light()` swaps bright ANSI colors for darker ones that stay readable on
+//! a white background.
+
+use ratatui::style::Color;
+
+use crate::config::ThemeName;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    pub accent: Color,
+    pub muted: Color,
+    pub selection_fg: Color,
+    pub selection_bg: Color,
+    pub header: Color,
+    pub success: Color,
+    pub keyword: Color,
+    pub selector: Color,
+    pub string_lit: Color,
+    pub number_lit: Color,
+    pub function: Color,
+    pub pipe: Color,
+    pub comment: Color,
+    pub match_fg: Color,
+    pub match_bg: Color,
+}
+
+impl Theme {
+    pub fn from_name(name: ThemeName) -> Self {
+        match name {
+            ThemeName::Dark => Self::dark(),
+            ThemeName::Light => Self::light(),
+        }
+    }
+
+    pub fn dark() -> Self {
+        Self {
+            accent: Color::Yellow,
+            muted: Color::DarkGray,
+            selection_fg: Color::Black,
+            selection_bg: Color::White,
+            header: Color::Cyan,
+            success: Color::Green,
+            keyword: Color::Magenta,
+            selector: Color::Cyan,
+            string_lit: Color::Green,
+            number_lit: Color::LightMagenta,
+            function: Color::LightBlue,
+            pipe: Color::Yellow,
+            comment: Color::DarkGray,
+            match_fg: Color::Black,
+            match_bg: Color::Yellow,
+        }
+    }
+
+    pub fn light() -> Self {
+        Self {
+            accent: Color::Rgb(150, 100, 0),
+            muted: Color::DarkGray,
+            selection_fg: Color::White,
+            selection_bg: Color::Rgb(0, 90, 200),
+            header: Color::Blue,
+            success: Color::Rgb(0, 120, 0),
+            keyword: Color::Rgb(150, 0, 130),
+            selector: Color::Blue,
+            string_lit: Color::Rgb(0, 120, 0),
+            number_lit: Color::Rgb(130, 0, 150),
+            function: Color::Rgb(0, 80, 200),
+            pipe: Color::Rgb(150, 100, 0),
+            comment: Color::DarkGray,
+            match_fg: Color::Black,
+            match_bg: Color::Rgb(255, 210, 0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_name_selects_correct_palette() {
+        let dark = Theme::from_name(ThemeName::Dark);
+        let light = Theme::from_name(ThemeName::Light);
+        assert_eq!(dark.accent, Color::Yellow);
+        assert_ne!(dark.accent, light.accent);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,6 +13,7 @@ use ratatui::{
 };
 
 use crate::app::{App, Mode};
+use crate::theme::Theme;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Break `line` into chunks of at most `width` display columns, preserving
@@ -49,7 +50,7 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
     }
     constraints.push(Constraint::Length(3)); // Query input / title bar
     constraints.push(Constraint::Min(0)); // Results area
-    constraints.push(Constraint::Length(1)); // Status line
+    constraints.push(Constraint::Length(1)); // Status line (+ key hints)
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -86,7 +87,13 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
     match display_mode {
         Mode::TreeView => {
             if let Some(tree_view) = app.tree_view() {
-                tree_view.render(frame, results_area);
+                let crumbs = tree_view.breadcrumb();
+                let title = if crumbs.is_empty() {
+                    "Document Tree".to_string()
+                } else {
+                    format!("Document Tree - {}", crumbs.join(" \u{203a} "))
+                };
+                tree_view.render_with_title(frame, results_area, &title);
             }
         }
         Mode::Preview => {
@@ -98,11 +105,12 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
         _ => {
             // Show sidebar if enabled
             if app.show_tree_sidebar() && app.sidebar_tree_view().is_some() {
+                let sidebar = app.sidebar_split_percent();
                 let main_chunks = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints([
-                        Constraint::Percentage(20), // Sidebar
-                        Constraint::Percentage(80), // Main content
+                        Constraint::Percentage(sidebar),        // Sidebar
+                        Constraint::Percentage(100 - sidebar), // Main content
                     ])
                     .split(results_area);
 
@@ -113,11 +121,12 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
 
                 // Draw main content area (results and/or detail)
                 if app.show_detail() && !app.results().is_empty() {
+                    let left = app.detail_split_percent();
                     let detail_chunks = Layout::default()
                         .direction(Direction::Horizontal)
                         .constraints([
-                            Constraint::Percentage(40), // Results list
-                            Constraint::Percentage(60), // Detail view
+                            Constraint::Percentage(left),       // Results list
+                            Constraint::Percentage(100 - left), // Detail view
                         ])
                         .split(main_chunks[1]);
 
@@ -129,11 +138,12 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
             } else {
                 // No sidebar - original layout
                 if app.show_detail() && !app.results().is_empty() {
+                    let left = app.detail_split_percent();
                     let detail_chunks = Layout::default()
                         .direction(Direction::Horizontal)
                         .constraints([
-                            Constraint::Percentage(40), // Results list
-                            Constraint::Percentage(60), // Detail view
+                            Constraint::Percentage(left),       // Results list
+                            Constraint::Percentage(100 - left), // Detail view
                         ])
                         .split(results_area);
 
@@ -161,12 +171,109 @@ pub fn draw_ui(frame: &mut Frame, app: &App) {
     }
 
     if app.mode() == Mode::Help {
-        draw_help_screen(frame);
+        draw_help_screen(frame, app);
     }
+
+    if app.mode() == Mode::CommandPalette {
+        draw_command_palette(frame, app);
+    }
+}
+
+/// Mode-specific key hints folded into the left side of the status line
+/// (toggle with `show_hint_bar` in config.toml, or `--no-hints`).
+fn hint_text(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Normal => {
+            ": query  t tree  p preview  s sidebar  d detail  y/Y copy  / search  Ctrl+K palette  ? help"
+        }
+        Mode::Query => "Enter run  Esc cancel  \u{2191}/\u{2193} history  Tab complete",
+        Mode::TreeView => "j/k move  Enter/Space expand  / search  Esc exit",
+        Mode::Preview => "j/k scroll  s split  </> resize  g/G top/bottom  Esc exit",
+        Mode::Search => "Enter confirm  Esc cancel",
+        Mode::SaveQuery => "Enter save  Esc cancel",
+        Mode::Favorites => "Enter run  d delete  Esc close",
+        Mode::CommandPalette => "type to filter  \u{2191}/\u{2193} select  Enter run  Esc close",
+        Mode::OpenFile => "Enter open  Esc cancel",
+        Mode::Help => "any key to close",
+    }
+}
+
+/// Command palette overlay: a fuzzy-filterable list of app actions (Ctrl+K).
+fn draw_command_palette(frame: &mut Frame, app: &App) {
+    let theme = app.theme();
+    let frame_area = frame.area();
+    let width = frame_area.width.clamp(30, 70).min(frame_area.width);
+    let height = frame_area.height.clamp(8, 16).min(frame_area.height);
+    let x = (frame_area.width.saturating_sub(width)) / 2;
+    let y = (frame_area.height.saturating_sub(height)) / 3;
+    let area = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, area);
+
+    let outer = Block::default()
+        .title("Command Palette")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded);
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(inner);
+
+    let query_line = Paragraph::new(Line::from(vec![
+        Span::styled("> ", Style::default().fg(theme.accent)),
+        Span::styled(app.palette_query(), Style::default().fg(theme.accent)),
+    ]));
+    frame.render_widget(query_line, chunks[0]);
+    frame.set_cursor_position(Position::new(
+        chunks[0].x + 2 + app.palette_cursor() as u16,
+        chunks[0].y,
+    ));
+
+    let matches = app.filtered_palette_actions();
+    let selected = app.palette_selected();
+
+    if matches.is_empty() {
+        let empty = Paragraph::new("No matching command").style(Style::default().fg(theme.muted));
+        frame.render_widget(empty, chunks[1]);
+        return;
+    }
+
+    let items: Vec<ListItem> = matches
+        .iter()
+        .enumerate()
+        .map(|(i, action)| {
+            let style = if i == selected {
+                Style::default()
+                    .fg(theme.selection_fg)
+                    .bg(theme.selection_bg)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.selector)
+            };
+            let desc_style = if i == selected {
+                style
+            } else {
+                Style::default().fg(theme.muted)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{:<20}", action.label), style),
+                Span::styled(action.description, desc_style),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items);
+    let mut state = ListState::default();
+    state.select(Some(selected));
+    frame.render_stateful_widget(list, chunks[1], &mut state);
 }
 
 /// Draw the tab bar showing all open documents, with the active one highlighted.
 fn draw_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let titles: Vec<Line> = app
         .document_names()
         .into_iter()
@@ -182,8 +289,8 @@ fn draw_tab_bar(frame: &mut Frame, app: &App, area: Rect) {
         .select(app.active_doc_index())
         .highlight_style(
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Yellow)
+                .fg(theme.selection_fg)
+                .bg(theme.accent)
                 .add_modifier(Modifier::BOLD),
         )
         .divider(Span::raw(" | "));
@@ -199,7 +306,7 @@ fn draw_open_file_input(frame: &mut Frame, app: &App, area: Rect) {
         .style(Style::default());
 
     let open_file_text = Paragraph::new(app.open_file_path())
-        .style(Style::default().fg(Color::Yellow))
+        .style(Style::default().fg(app.theme().accent))
         .block(open_file_block);
 
     frame.render_widget(open_file_text, area);
@@ -217,7 +324,7 @@ fn draw_search_input(frame: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL);
 
     let text = Paragraph::new(app.search_query())
-        .style(Style::default().fg(Color::Yellow))
+        .style(Style::default().fg(app.theme().accent))
         .block(block);
 
     frame.render_widget(text, area);
@@ -235,7 +342,7 @@ fn draw_save_query_input(frame: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL);
 
     let text = Paragraph::new(app.save_query_name())
-        .style(Style::default().fg(Color::Yellow))
+        .style(Style::default().fg(app.theme().accent))
         .block(block);
 
     frame.render_widget(text, area);
@@ -245,6 +352,7 @@ fn draw_save_query_input(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_favorites_list(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let saved = app.saved_queries();
     let block = Block::default()
         .title("Favorites (Enter to run, d to delete, Esc to close)")
@@ -252,7 +360,7 @@ fn draw_favorites_list(frame: &mut Frame, app: &App, area: Rect) {
 
     if saved.is_empty() {
         let text = Paragraph::new("No saved queries yet - press 'S' to save the current query")
-            .style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().fg(theme.muted))
             .block(block);
         frame.render_widget(text, area);
         return;
@@ -266,14 +374,22 @@ fn draw_favorites_list(frame: &mut Frame, app: &App, area: Rect) {
         .map(|(i, saved)| {
             let is_selected = i == app.favorites_selected();
             let style = if is_selected {
-                Style::default().fg(Color::Black).bg(Color::White)
+                Style::default()
+                    .fg(theme.selection_fg)
+                    .bg(theme.selection_bg)
             } else {
                 Style::default()
             };
-            let name_style = style
-                .add_modifier(Modifier::BOLD)
-                .fg(if is_selected { Color::Black } else { Color::Cyan });
-            let query_style = style.fg(if is_selected { Color::Black } else { Color::Gray });
+            let name_style = style.add_modifier(Modifier::BOLD).fg(if is_selected {
+                theme.selection_fg
+            } else {
+                theme.selector
+            });
+            let query_style = style.fg(if is_selected {
+                theme.selection_fg
+            } else {
+                theme.muted
+            });
 
             let text = format!("{}  {}", saved.name, saved.query);
             let name_len = saved.name.chars().count();
@@ -307,32 +423,39 @@ fn draw_favorites_list(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 const QUERY_KEYWORDS: &[&str] = &[
-    "and", "as", "break", "catch", "continue", "def", "do", "elif", "else", "end", "fn",
-    "foreach", "if", "import", "include", "let", "loop", "match", "module", "nodes", "none",
-    "not", "or", "self", "true", "false", "try", "unless", "until", "var", "while",
+    "and", "as", "break", "catch", "continue", "def", "do", "elif", "else", "end", "fn", "foreach",
+    "if", "import", "include", "let", "loop", "match", "module", "nodes", "none", "not", "or",
+    "self", "true", "false", "try", "unless", "until", "var", "while",
 ];
 
 /// Best-effort tokenizer for coloring the query bar as the user types.
 /// Not a real lexer (mq-lang's isn't public) — just close enough for display.
-fn highlight_query(query: &str) -> Vec<Span<'static>> {
+fn highlight_query(query: &str, theme: &Theme) -> Vec<Span<'static>> {
     let chars: Vec<char> = query.chars().collect();
     let mut spans = Vec::new();
     let mut i = 0;
 
-    let selector_style = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
-    let keyword_style = Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD);
-    let string_style = Style::default().fg(Color::Green);
-    let number_style = Style::default().fg(Color::LightMagenta);
-    let function_style = Style::default().fg(Color::LightBlue);
-    let pipe_style = Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD);
-    let comment_style = Style::default().fg(Color::DarkGray);
-    let default_style = Style::default().fg(Color::Yellow);
+    let selector_style = Style::default()
+        .fg(theme.selector)
+        .add_modifier(Modifier::BOLD);
+    let keyword_style = Style::default()
+        .fg(theme.keyword)
+        .add_modifier(Modifier::BOLD);
+    let string_style = Style::default().fg(theme.string_lit);
+    let number_style = Style::default().fg(theme.number_lit);
+    let function_style = Style::default().fg(theme.function);
+    let pipe_style = Style::default().fg(theme.pipe).add_modifier(Modifier::BOLD);
+    let comment_style = Style::default().fg(theme.comment);
+    let default_style = Style::default().fg(theme.accent);
 
     while i < chars.len() {
         let c = chars[i];
 
         if c == '#' {
-            spans.push(Span::styled(chars[i..].iter().collect::<String>(), comment_style));
+            spans.push(Span::styled(
+                chars[i..].iter().collect::<String>(),
+                comment_style,
+            ));
             break;
         }
 
@@ -350,7 +473,10 @@ fn highlight_query(query: &str) -> Vec<Span<'static>> {
                     break;
                 }
             }
-            spans.push(Span::styled(chars[start..i].iter().collect::<String>(), string_style));
+            spans.push(Span::styled(
+                chars[start..i].iter().collect::<String>(),
+                string_style,
+            ));
             continue;
         }
 
@@ -359,7 +485,10 @@ fn highlight_query(query: &str) -> Vec<Span<'static>> {
             while i < chars.len() && (chars[i].is_ascii_digit() || chars[i] == '.') {
                 i += 1;
             }
-            spans.push(Span::styled(chars[start..i].iter().collect::<String>(), number_style));
+            spans.push(Span::styled(
+                chars[start..i].iter().collect::<String>(),
+                number_style,
+            ));
             continue;
         }
 
@@ -371,7 +500,10 @@ fn highlight_query(query: &str) -> Vec<Span<'static>> {
             {
                 i += 1;
             }
-            spans.push(Span::styled(chars[start..i].iter().collect::<String>(), selector_style));
+            spans.push(Span::styled(
+                chars[start..i].iter().collect::<String>(),
+                selector_style,
+            ));
             continue;
         }
 
@@ -408,32 +540,52 @@ fn highlight_query(query: &str) -> Vec<Span<'static>> {
         {
             i += 1;
         }
-        spans.push(Span::styled(chars[start..i].iter().collect::<String>(), default_style));
+        spans.push(Span::styled(
+            chars[start..i].iter().collect::<String>(),
+            default_style,
+        ));
     }
 
     spans
 }
 
 fn draw_query_input(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let has_error = app.error_msg().is_some();
     let mut query_block = Block::default().title("Query").borders(Borders::ALL);
 
     if let Some(error) = app.error_msg() {
         query_block = query_block.title_bottom(
-            Line::from(Span::styled(error.to_string(), Style::default().fg(Color::Red)))
-                .alignment(Alignment::Left),
+            Line::from(Span::styled(
+                error.to_string(),
+                Style::default().fg(Color::Red),
+            ))
+            .alignment(Alignment::Left),
         );
     }
 
     // A broken query turns fully red/underlined; otherwise it's syntax-highlighted.
-    let spans = if has_error {
+    let mut spans = if has_error {
         vec![Span::styled(
             app.query().to_string(),
-            Style::default().fg(Color::Red).add_modifier(Modifier::UNDERLINED),
+            Style::default()
+                .fg(Color::Red)
+                .add_modifier(Modifier::UNDERLINED),
         )]
     } else {
-        highlight_query(app.query())
+        highlight_query(app.query(), &theme)
     };
+
+    // Inline "ghost text": the remainder of the top completion candidate,
+    // shown dimmed after the cursor (fish-shell style autosuggestion).
+    if !has_error && let Some(suffix) = app.ghost_suffix() {
+        spans.push(Span::styled(
+            suffix,
+            Style::default()
+                .fg(theme.muted)
+                .add_modifier(Modifier::ITALIC),
+        ));
+    }
 
     let query_text = Paragraph::new(Line::from(spans)).block(query_block);
 
@@ -448,6 +600,7 @@ fn draw_query_input(frame: &mut Frame, app: &App, area: Rect) {
 
 /// Completion suggestions popup under the query box; Tab accepts the first entry.
 fn draw_completions_popup(frame: &mut Frame, app: &App, header_area: Rect) {
+    let theme = app.theme();
     let completions = app.active_completions();
     if completions.is_empty() {
         return;
@@ -471,15 +624,15 @@ fn draw_completions_popup(frame: &mut Frame, app: &App, header_area: Rect) {
         .map(|(i, (name, description))| {
             let style = if i == selected {
                 Style::default()
-                    .fg(Color::Black)
-                    .bg(Color::Yellow)
+                    .fg(theme.selection_fg)
+                    .bg(theme.accent)
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(Color::Cyan)
+                Style::default().fg(theme.selector)
             };
             ListItem::new(Line::from(vec![
                 Span::styled(format!(" {name} "), style),
-                Span::styled(format!(" {description}"), Style::default().fg(Color::Gray)),
+                Span::styled(format!(" {description}"), Style::default().fg(theme.muted)),
             ]))
         })
         .collect();
@@ -496,6 +649,7 @@ fn draw_completions_popup(frame: &mut Frame, app: &App, header_area: Rect) {
 }
 
 fn draw_results_list(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let results = app.results();
 
     let results_block = Block::default().title("Results").borders(Borders::ALL);
@@ -508,7 +662,7 @@ fn draw_results_list(frame: &mut Frame, app: &App, area: Rect) {
         };
 
         let empty_text = Paragraph::new(text)
-            .style(Style::default().fg(Color::DarkGray))
+            .style(Style::default().fg(theme.muted))
             .block(results_block);
 
         frame.render_widget(empty_text, area);
@@ -553,18 +707,22 @@ fn draw_results_list(frame: &mut Frame, app: &App, area: Rect) {
             let is_selected = i >= selected_line && i < selected_end_line;
             let base_style = if is_markdown_header(value) {
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme.header)
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
             };
             let lines: Vec<Line> = wrap_to_width(value, wrap_width)
                 .iter()
-                .map(|segment| Line::from(highlight_matches(segment, search_term, base_style)))
+                .map(|segment| {
+                    Line::from(highlight_matches(segment, search_term, base_style, &theme))
+                })
                 .collect();
 
             ListItem::new(lines).style(if is_selected {
-                Style::default().fg(Color::Black).bg(Color::White)
+                Style::default()
+                    .fg(theme.selection_fg)
+                    .bg(theme.selection_bg)
             } else {
                 Style::default()
             })
@@ -654,7 +812,12 @@ fn draw_preview(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 /// Style every case-insensitive occurrence of `term` in `line` distinctly.
-fn highlight_matches(line: &str, term: Option<&str>, base_style: Style) -> Vec<Span<'static>> {
+fn highlight_matches(
+    line: &str,
+    term: Option<&str>,
+    base_style: Style,
+    theme: &Theme,
+) -> Vec<Span<'static>> {
     let Some(term) = term else {
         return vec![Span::styled(line.to_string(), base_style)];
     };
@@ -672,8 +835,8 @@ fn highlight_matches(line: &str, term: Option<&str>, base_style: Style) -> Vec<S
         spans.push(Span::styled(
             line[match_start..match_end].to_string(),
             base_style
-                .fg(Color::Black)
-                .bg(Color::Yellow)
+                .fg(theme.match_fg)
+                .bg(theme.match_bg)
                 .add_modifier(Modifier::BOLD),
         ));
         pos = match_end;
@@ -694,8 +857,10 @@ fn is_markdown_header(line: &str) -> bool {
     trimmed.starts_with('#') && trimmed.chars().nth(1).is_some_and(|c| c == ' ' || c == '#')
 }
 
-/// Draw the status line at the bottom
+/// Draw the status line at the bottom, folding in the mode-specific key
+/// hints (when enabled) so the bottom bar stays a single line.
 fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let exec_time = app.last_exec_time();
     let results_count = app.results().len();
 
@@ -707,38 +872,67 @@ fn draw_status_line(frame: &mut Frame, app: &App, area: Rect) {
 
     let watch_info = if app.watch() { "👀 watching | " } else { "" };
 
+    let show_hints = app.show_hint_bar();
     let status = format!(
-        "{}{}{} results | Execution time: {:.2}ms | Press q to quit",
+        "{}{}{} results | {:.2}ms{}",
         watch_info,
         doc_info,
         results_count,
-        exec_time.as_secs_f64() * 1000.0
+        exec_time.as_secs_f64() * 1000.0,
+        if show_hints { "" } else { " | Press q to quit" }
     );
 
-    let status_text = Paragraph::new(status).style(Style::default().fg(Color::DarkGray));
+    if !show_hints {
+        frame.render_widget(
+            Paragraph::new(status).style(Style::default().fg(theme.muted)),
+            area,
+        );
+        return;
+    }
 
-    frame.render_widget(status_text, area);
+    let display_mode = if app.mode() == Mode::Search {
+        app.search_return_mode()
+    } else {
+        app.mode()
+    };
+    let status_width = status.width() as u16;
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(0), Constraint::Length(status_width)])
+        .split(area);
+
+    frame.render_widget(
+        Paragraph::new(hint_text(display_mode)).style(Style::default().fg(theme.muted)),
+        chunks[0],
+    );
+    frame.render_widget(
+        Paragraph::new(status)
+            .style(Style::default().fg(theme.muted))
+            .alignment(Alignment::Right),
+        chunks[1],
+    );
 }
 
 fn draw_title_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme();
     let title = app.filename().unwrap_or("None");
     let title_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded);
 
     let title_spans = vec![
-        Span::styled(title, Style::default().fg(Color::Green).bold()),
+        Span::styled(title, Style::default().fg(theme.success).bold()),
         Span::raw(" | "),
         Span::styled(
             app.mode().to_string(),
             Style::default()
-                .fg(Color::Yellow)
+                .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" | "),
         Span::styled(
             "Press 's' for sidebar, 't' for tree view, 'p' for preview, 'o' to open a file, '?' for help",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.muted),
         ),
     ];
 
@@ -756,8 +950,14 @@ fn draw_detail_view(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     let selected_item = &results[app.selected_idx()];
+    let title = format!(
+        "Detail View - {}/{} \u{203a} {}",
+        app.selected_idx() + 1,
+        results.len(),
+        node_type_label(selected_item)
+    );
     let detail_block = Block::default()
-        .title("Detail View")
+        .title(title)
         .borders(Borders::ALL)
         .border_type(BorderType::Plain)
         .padding(Padding::new(1, 1, 1, 1));
@@ -770,6 +970,49 @@ fn draw_detail_view(frame: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false });
 
     frame.render_widget(detail_text, area);
+}
+
+/// Short variant name for a node, used in the detail view's breadcrumb title.
+fn node_type_label(node: &mq_markdown::Node) -> &'static str {
+    use mq_markdown::Node;
+    match node {
+        Node::Heading(_) => "Heading",
+        Node::List(_) => "List",
+        Node::Code(_) => "Code Block",
+        Node::CodeInline(_) => "Inline Code",
+        Node::Blockquote(_) => "Blockquote",
+        Node::Strong(_) => "Strong",
+        Node::Emphasis(_) => "Emphasis",
+        Node::Delete(_) => "Strikethrough",
+        Node::Link(_) => "Link",
+        Node::LinkRef(_) => "Link Ref",
+        Node::Image(_) => "Image",
+        Node::ImageRef(_) => "Image Ref",
+        Node::Text(_) => "Text",
+        Node::HorizontalRule(_) => "Horizontal Rule",
+        Node::TableAlign(_) => "Table Header",
+        Node::TableRow(_) => "Table Row",
+        Node::TableCell(_) => "Table Cell",
+        Node::Break(_) => "Line Break",
+        Node::Html(_) => "HTML",
+        Node::Math(_) => "Math",
+        Node::MathInline(_) => "Inline Math",
+        Node::Yaml(_) => "YAML",
+        Node::Toml(_) => "TOML",
+        Node::Fragment(_) => "Fragment",
+        Node::Footnote(_) => "Footnote",
+        Node::FootnoteRef(_) => "Footnote Ref",
+        Node::Definition(_) => "Definition",
+        Node::MdxFlowExpression(_) => "MDX Flow Expression",
+        Node::MdxJsxFlowElement(_) => "MDX JSX Element",
+        Node::MdxJsxTextElement(_) => "MDX JSX Text",
+        Node::MdxTextExpression(_) => "MDX Text Expression",
+        Node::MdxJsEsm(_) => "MDX JS ESM",
+        Node::Empty => "Empty",
+        Node::Callout(_) => "Callout",
+        Node::Embed(_) => "Embed",
+        Node::WikiLink(_) => "WikiLink",
+    }
 }
 
 fn max_line_width(lines: &[Line]) -> u16 {
@@ -785,7 +1028,7 @@ fn max_line_width(lines: &[Line]) -> u16 {
         .unwrap_or(0) as u16
 }
 
-fn draw_help_screen(frame: &mut Frame) {
+fn draw_help_screen(frame: &mut Frame, app: &App) {
     let area = frame.area();
 
     let help_block = Block::default()
@@ -936,6 +1179,14 @@ fn draw_help_screen(frame: &mut Frame) {
             Span::styled("Ctrl+l", Style::default().fg(Color::Yellow)),
             Span::raw(" - Clear query"),
         ]),
+        Line::from(vec![
+            Span::styled("Ctrl+k", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Open command palette"),
+        ]),
+        Line::from(vec![
+            Span::styled("</>", Style::default().fg(Color::Yellow)),
+            Span::raw(" - Resize sidebar/detail/preview split"),
+        ]),
         Line::from(""),
         Line::from(vec![Span::styled(
             "Tabs / Files",
@@ -1059,8 +1310,30 @@ fn draw_help_screen(frame: &mut Frame) {
         ])
         .split(inner);
 
-    frame.render_widget(Paragraph::new(left_column).alignment(Alignment::Left), columns[0]);
-    frame.render_widget(Paragraph::new(right_column).alignment(Alignment::Left), columns[2]);
+    frame.render_widget(
+        Paragraph::new(left_column).alignment(Alignment::Left),
+        columns[0],
+    );
+    frame.render_widget(
+        Paragraph::new(right_column).alignment(Alignment::Left),
+        columns[2],
+    );
+
+    let footer = format!(
+        "Theme: {:?} | Hint bar: {} (config.toml)",
+        app.theme_name(),
+        if app.show_hint_bar() { "on" } else { "off" }
+    );
+    let footer_area = Rect::new(
+        help_area.x + 1,
+        help_area.y + help_area.height - 1,
+        help_area.width.saturating_sub(2),
+        1,
+    );
+    frame.render_widget(
+        Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)),
+        footer_area,
+    );
 }
 
 fn draw_error_popup(frame: &mut Frame, error: &str) {
@@ -1106,7 +1379,8 @@ mod tests {
 
     #[test]
     fn test_highlight_query_classifies_tokens() {
-        let spans = highlight_query(r#".h | select(.depth == 1) # note"#);
+        let theme = Theme::dark();
+        let spans = highlight_query(r#".h | select(.depth == 1) # note"#, &theme);
         let plain: Vec<String> = spans.iter().map(|s| s.content.to_string()).collect();
 
         assert!(plain.contains(&".h".to_string()));
@@ -1117,15 +1391,16 @@ mod tests {
         assert!(plain.iter().any(|s| s.starts_with('#')));
 
         let selector_span = spans.iter().find(|s| s.content == ".h").unwrap();
-        assert_eq!(selector_span.style.fg, Some(Color::Cyan));
+        assert_eq!(selector_span.style.fg, Some(theme.selector));
 
         let function_span = spans.iter().find(|s| s.content == "select").unwrap();
-        assert_eq!(function_span.style.fg, Some(Color::LightBlue));
+        assert_eq!(function_span.style.fg, Some(theme.function));
     }
 
     #[test]
     fn test_highlight_query_string_literal_is_single_span() {
-        let spans = highlight_query(r#"select(.text == "hello world")"#);
+        let theme = Theme::dark();
+        let spans = highlight_query(r#"select(.text == "hello world")"#, &theme);
         assert!(spans.iter().any(|s| s.content == "\"hello world\""));
     }
 
@@ -1404,10 +1679,11 @@ mod tests {
     #[test]
     fn test_draw_help_screen_content() {
         let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        let app = create_test_app();
 
         terminal
             .draw(|frame| {
-                draw_help_screen(frame);
+                draw_help_screen(frame, &app);
             })
             .unwrap();
 

--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -268,7 +268,11 @@ fn is_table_separator(line: &str) -> bool {
     })
 }
 
-fn table_row_spans(raw: &str, cell_style: Style, defs: &HashMap<String, String>) -> Vec<Span<'static>> {
+fn table_row_spans(
+    raw: &str,
+    cell_style: Style,
+    defs: &HashMap<String, String>,
+) -> Vec<Span<'static>> {
     let cells: Vec<&str> = raw.trim().trim_matches('|').split('|').collect();
     let mut spans = Vec::new();
     for (idx, cell) in cells.iter().enumerate() {
@@ -500,7 +504,11 @@ fn parse_inline(text: &str, base: Style, defs: &HashMap<String, String>) -> Vec<
             && !inner.is_empty()
         {
             flush(&mut buf, &mut spans, base);
-            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::BOLD), defs));
+            spans.extend(parse_inline(
+                &inner,
+                base.add_modifier(Modifier::BOLD),
+                defs,
+            ));
             i += consumed;
             continue;
         }
@@ -510,7 +518,11 @@ fn parse_inline(text: &str, base: Style, defs: &HashMap<String, String>) -> Vec<
             && !inner.is_empty()
         {
             flush(&mut buf, &mut spans, base);
-            spans.extend(parse_inline(&inner, base.add_modifier(Modifier::ITALIC), defs));
+            spans.extend(parse_inline(
+                &inner,
+                base.add_modifier(Modifier::ITALIC),
+                defs,
+            ));
             i += consumed;
             continue;
         }

--- a/src/ui/treeview.rs
+++ b/src/ui/treeview.rs
@@ -313,6 +313,43 @@ impl TreeView {
         &self.items
     }
 
+    /// Labels for the selected node and its ancestors, root first, found by
+    /// scanning backward for the nearest preceding item at each shallower depth.
+    pub fn breadcrumb(&self) -> Vec<String> {
+        let Some(selected) = self.items.get(self.selected_index) else {
+            return Vec::new();
+        };
+        if selected.is_all_documents {
+            return vec![selected.display_text.clone()];
+        }
+
+        let mut labels = vec![Self::breadcrumb_label(selected)];
+        let mut want_depth = selected.depth;
+
+        for item in self.items[..self.selected_index].iter().rev() {
+            if want_depth == 0 {
+                break;
+            }
+            if item.depth == want_depth - 1 {
+                labels.push(Self::breadcrumb_label(item));
+                want_depth = item.depth;
+            }
+        }
+
+        labels.reverse();
+        labels
+    }
+
+    fn breadcrumb_label(item: &TreeItem) -> String {
+        const MAX_LEN: usize = 28;
+        let text = &item.display_text;
+        if text.chars().count() > MAX_LEN {
+            format!("{}\u{2026}", text.chars().take(MAX_LEN).collect::<String>())
+        } else {
+            text.clone()
+        }
+    }
+
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         self.render_with_title(frame, area, "Document Tree");
     }
@@ -1203,5 +1240,28 @@ mod tests {
 
         // This test mainly verifies that rendering doesn't panic and produces output
         assert!(has_content, "Should have rendered content");
+    }
+
+    #[test]
+    fn test_breadcrumb_root_is_single_label() {
+        let nodes = vec![create_test_heading(), create_test_text()];
+        let tree_view = TreeView::new(nodes);
+        assert_eq!(tree_view.breadcrumb(), vec!["# Test Heading".to_string()]);
+    }
+
+    #[test]
+    fn test_breadcrumb_includes_ancestors() {
+        let nodes = vec![create_test_heading()];
+        let mut tree_view = TreeView::new(nodes);
+        tree_view.toggle_expand();
+        tree_view.move_down();
+
+        assert_eq!(
+            tree_view.breadcrumb(),
+            vec![
+                "# Test Heading".to_string(),
+                "Text: Test Heading".to_string()
+            ]
+        );
     }
 }


### PR DESCRIPTION
Adds a Ctrl+K fuzzy command palette, dark/light color themes (config.toml or --theme), a status-line key-hint bar (toggleable via show_hint_bar/--no-hints), inline ghost-text query completion, and </>-resizable sidebar/detail/preview splits. Also adds breadcrumb titles to the tree view and detail view for orientation in nested documents.